### PR TITLE
Centralize pk generation

### DIFF
--- a/apps/account/lib/account/model/account.ex
+++ b/apps/account/lib/account/model/account.ex
@@ -37,6 +37,7 @@ defmodule Helix.Account.Model.Account do
 
   @derive {Poison.Encoder, only: [:email, :username, :account_id]}
   @primary_key false
+  @ecto_autogenerate {:account_id, {PK, :pk_for, [__MODULE__]}}
   schema "accounts" do
     field :account_id, HELL.PK,
       primary_key: true
@@ -57,7 +58,6 @@ defmodule Helix.Account.Model.Account do
     |> cast(params, @creation_fields)
     |> generic_validations()
     |> prepare_changes()
-    |> put_primary_key()
   end
 
   @spec update_changeset(t | Ecto.Changeset.t, update_params) :: Ecto.Changeset.f
@@ -86,12 +86,6 @@ defmodule Helix.Account.Model.Account do
     |> update_change(:email, &String.downcase/1)
     |> update_change(:username, &String.downcase/1)
     |> update_change(:password, &Bcrypt.hashpwsalt/1)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    pk = PK.generate([0x0000, 0x0000, 0x0000])
-    put_change(changeset, :account_id, pk)
   end
 
   @spec put_display_name(Ecto.Changeset.t) :: Ecto.Changeset.t

--- a/apps/account/lib/account/model/account.ex
+++ b/apps/account/lib/account/model/account.ex
@@ -32,7 +32,7 @@ defmodule Helix.Account.Model.Account do
     optional(:password) => password,
     optional(:confirmed) => boolean}
 
-  @creation_fields ~w/account_id email username password/a
+  @creation_fields ~w/email username password/a
   @update_fields ~w/email password confirmed/a
 
   @derive {Poison.Encoder, only: [:email, :username, :account_id]}

--- a/apps/account/test/model/account_setting_test.exs
+++ b/apps/account/test/model/account_setting_test.exs
@@ -2,6 +2,8 @@ defmodule Helix.Account.Model.AccountSettingTest do
 
   use ExUnit.Case, async: true
 
+  alias HELL.PK
+  alias Helix.Account.Model.Account
   alias Helix.Account.Model.AccountSetting
 
   alias Helix.Account.Factory
@@ -10,7 +12,7 @@ defmodule Helix.Account.Model.AccountSettingTest do
     s = Factory.build(:account_setting)
 
     %{
-      account_id: s.account.account_id,
+      account_id: PK.pk_for(Account),
       setting_id: s.setting.setting_id,
       setting_value: s.setting_value
     }

--- a/apps/account/test/support/factory.ex
+++ b/apps/account/test/support/factory.ex
@@ -9,7 +9,7 @@ defmodule Helix.Account.Factory do
   alias Helix.Account.Model.Setting
 
   def account_factory do
-    pk = PK.generate([0x0000, 0x0000, 0x0000])
+    pk = PK.pk_for(Account)
     display_name = Random.username()
     username = String.downcase(display_name)
 

--- a/apps/account/test/support/factory.ex
+++ b/apps/account/test/support/factory.ex
@@ -2,19 +2,16 @@ defmodule Helix.Account.Factory do
 
   use ExMachina.Ecto, repo: Helix.Account.Repo
 
-  alias HELL.PK
   alias HELL.TestHelper.Random
   alias Helix.Account.Model.Account
   alias Helix.Account.Model.AccountSetting
   alias Helix.Account.Model.Setting
 
   def account_factory do
-    pk = PK.pk_for(Account)
     display_name = Random.username()
     username = String.downcase(display_name)
 
     %Account{
-      account_id: pk,
       username: display_name,
       display_name: username,
       email: Burette.Internet.email(),

--- a/apps/entity/test/controller/entity_component_test.exs
+++ b/apps/entity/test/controller/entity_component_test.exs
@@ -2,31 +2,34 @@ defmodule Helix.Entity.Controller.EntityComponentTest do
 
   use ExUnit.Case, async: true
 
+  alias HELL.PK
   alias Helix.Entity.Controller.EntityComponent, as: EntityComponentController
+  alias Helix.Entity.Model.Entity
+  alias Helix.Hardware.Model.Component
 
   alias Helix.Entity.Factory
 
   describe "adding entity ownership over components" do
     test "succeeds with entity_id" do
       %{entity_id: entity_id} = Factory.insert(:entity)
-      %{component_id: comp_id} = Factory.build(:entity_component)
+      comp_id = PK.pk_for(Component)
 
       assert {:ok, _} = EntityComponentController.create(entity_id, comp_id)
     end
 
     test "succeeds with entity struct" do
       entity = Factory.insert(:entity)
-      %{component_id: component_id} = Factory.build(:entity_component)
+      component_id = PK.pk_for(Component)
 
       assert {:ok, _} = EntityComponentController.create(entity, component_id)
     end
 
     test "fails when entity doesn't exist" do
-      %{entity_id: entity_id} = Factory.build(:entity)
-      %{component_id: component} = Factory.build(:entity_component)
+      entity_id = PK.pk_for(Entity)
+      component_id = PK.pk_for(Component)
 
       assert_raise(Ecto.ConstraintError, fn ->
-        EntityComponentController.create(entity_id, component)
+        EntityComponentController.create(entity_id, component_id)
       end)
     end
   end

--- a/apps/entity/test/controller/entity_server_test.exs
+++ b/apps/entity/test/controller/entity_server_test.exs
@@ -2,31 +2,34 @@ defmodule Helix.Entity.Controller.EntityServerTest do
 
   use ExUnit.Case, async: true
 
+  alias HELL.PK
   alias Helix.Entity.Controller.EntityServer, as: EntityServerController
+  alias Helix.Entity.Model.Entity
+  alias Helix.Server.Model.Server
 
   alias Helix.Entity.Factory
 
   describe "adding entity ownership over servers" do
     test "succeeds with entity_id" do
       %{entity_id: entity_id} = Factory.insert(:entity)
-      %{server_id: server_id} = Factory.build(:entity_server)
+      server_id = PK.pk_for(Server)
 
       assert {:ok, _} = EntityServerController.create(entity_id, server_id)
     end
 
     test "succeeds with entity struct" do
       entity = Factory.insert(:entity)
-      %{server_id: server_id} = Factory.build(:entity_server)
+      server_id = PK.pk_for(Server)
 
       assert {:ok, _} = EntityServerController.create(entity, server_id)
     end
 
     test "fails when entity doesn't exist" do
-      %{entity_id: entity_id} = Factory.build(:entity)
-      %{server_id: server} = Factory.build(:entity_server)
+      entity_id = PK.pk_for(Entity)
+      server_id = PK.pk_for(Server)
 
       assert_raise(Ecto.ConstraintError, fn ->
-        EntityServerController.create(entity_id, server)
+        EntityServerController.create(entity_id, server_id)
       end)
     end
   end

--- a/apps/entity/test/support/factory.ex
+++ b/apps/entity/test/support/factory.ex
@@ -8,17 +8,11 @@ defmodule Helix.Entity.Factory do
   alias Helix.Entity.Model.EntityComponent
   alias Helix.Entity.Model.EntityServer
 
-  @entity_types %{
-    "account"                => Helix.Account.Model.Account,
-    "clan"                   => Helix.Clan.Model.Clan,
-    "npc"                    => Helix.NPC.Model.NPC
-  }
-
   def entity_factory do
     entity_type = generate_entity_type()
 
     %Entity{
-      entity_id: generate_pk(entity_type),
+      entity_id: PK.pk_for(Entity),
       entity_type: entity_type
     }
   end
@@ -39,9 +33,4 @@ defmodule Helix.Entity.Factory do
 
   defp generate_entity_type,
     do: Enum.random(["account", "clan", "npc"])
-
-  for {entity_type, module} <- @entity_types do
-    defp generate_pk(unquote(entity_type)),
-      do: PK.pk_for(unquote(module))
-  end
 end

--- a/apps/entity/test/support/factory.ex
+++ b/apps/entity/test/support/factory.ex
@@ -8,6 +8,12 @@ defmodule Helix.Entity.Factory do
   alias Helix.Entity.Model.EntityComponent
   alias Helix.Entity.Model.EntityServer
 
+  @entity_types %{
+    "account"                => Helix.Account.Model.Account,
+    "clan"                   => Helix.Clan.Model.Clan,
+    "npc"                    => Helix.NPC.Model.NPC
+  }
+
   def entity_factory do
     entity_type = generate_entity_type()
 
@@ -31,11 +37,11 @@ defmodule Helix.Entity.Factory do
     }
   end
 
-  def generate_entity_type,
+  defp generate_entity_type,
     do: Enum.random(["account", "clan", "npc"])
 
-  def generate_pk("account"),
-    do: PK.generate([0x0000, 0x0000, 0x0000])
-  def generate_pk(_),
-    do: Random.pk()
+  for {entity_type, module} <- @entity_types do
+    defp generate_pk(unquote(entity_type)),
+      do: PK.pk_for(unquote(module))
+  end
 end

--- a/apps/hardware/lib/hardware/model/component/cpu.ex
+++ b/apps/hardware/lib/hardware/model/component/cpu.ex
@@ -33,7 +33,7 @@ defmodule Helix.Hardware.Model.Component.CPU do
   end
 
   def create_from_spec(cs = %ComponentSpec{spec: spec}) do
-    cpu_id = PK.generate([0x0003, 0x0001, 0x0002])
+    cpu_id = PK.pk_for(__MODULE__)
     params = Map.take(spec, ["clock", "cores"])
 
     component = Component.create_from_spec(cs, cpu_id)

--- a/apps/hardware/lib/hardware/model/component/hdd.ex
+++ b/apps/hardware/lib/hardware/model/component/hdd.ex
@@ -30,7 +30,7 @@ defmodule Helix.Hardware.Model.Component.HDD do
   end
 
   def create_from_spec(cs = %ComponentSpec{spec: spec}) do
-    hdd_id = PK.generate([0x0003, 0x0001, 0x0001])
+    hdd_id = PK.pk_for(__MODULE__)
     params = Map.take(spec, ["hdd_size"])
     component = Component.create_from_spec(cs, hdd_id)
 

--- a/apps/hardware/lib/hardware/model/component/nic.ex
+++ b/apps/hardware/lib/hardware/model/component/nic.ex
@@ -39,7 +39,7 @@ defmodule Helix.Hardware.Model.Component.NIC do
   end
 
   def create_from_spec(cs = %ComponentSpec{spec: _}) do
-    nic_id = PK.generate([0x0003, 0x0001, 0x0004])
+    nic_id = PK.pk_for(__MODULE__)
     component = Component.create_from_spec(cs, nic_id)
 
     %__MODULE__{}

--- a/apps/hardware/lib/hardware/model/component/ram.ex
+++ b/apps/hardware/lib/hardware/model/component/ram.ex
@@ -31,7 +31,7 @@ defmodule Helix.Hardware.Model.Component.RAM do
 
   def create_from_spec(cs = %ComponentSpec{spec: spec}) do
     params = Map.take(spec, ["ram_size"])
-    ram_id = PK.generate([0x0003, 0x0001, 0x0003])
+    ram_id = PK.pk_for(__MODULE__)
     component = Component.create_from_spec(cs, ram_id)
 
     %__MODULE__{}

--- a/apps/hardware/lib/hardware/model/motherboard.ex
+++ b/apps/hardware/lib/hardware/model/motherboard.ex
@@ -39,7 +39,7 @@ defmodule Helix.Hardware.Model.Motherboard do
   end
 
   def create_from_spec(cs = %ComponentSpec{spec: spec = %{"slots" => _}}) do
-    motherboard_id = PK.generate([0x0003, 0x0001, 0x0000])
+    motherboard_id = PK.pk_for(__MODULE__)
 
     slots = Enum.map(Map.get(spec, "slots"), fn {id, spec} ->
       params = %{

--- a/apps/hardware/lib/hardware/model/motherboard_slot.ex
+++ b/apps/hardware/lib/hardware/model/motherboard_slot.ex
@@ -35,6 +35,7 @@ defmodule Helix.Hardware.Model.MotherboardSlot do
   @required_fields ~w/motherboard_id link_component_type slot_internal_id/a
 
   @primary_key false
+  @ecto_autogenerate {:slot_id, {PK, :pk_for, [__MODULE__]}}
   schema "motherboard_slots" do
     field :slot_id, HELL.PK,
       primary_key: true
@@ -61,7 +62,8 @@ defmodule Helix.Hardware.Model.MotherboardSlot do
     %__MODULE__{}
     |> cast(params, @creation_fields)
     |> changeset(params)
-    |> put_primary_key()
+    |> validate_required([:motherboard_id, :link_component_type, :slot_internal_id])
+    |> unique_constraint(:link_component_id, name: :motherboard_slots_link_component_id_index)
   end
 
   @spec update_changeset(t | Ecto.Changeset.t, update_params) :: Ecto.Changeset.t
@@ -74,16 +76,6 @@ defmodule Helix.Hardware.Model.MotherboardSlot do
     |> cast(params, @accepted_fields)
     |> validate_required(@required_fields)
     |> unique_constraint(:link_component_id)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    if get_field(changeset, :slot_id) do
-      changeset
-    else
-      pk = PK.pk_for(__MODULE__)
-      cast(changeset, %{slot_id: pk}, [:slot_id])
-    end
   end
 
   @spec linked?(t) :: boolean

--- a/apps/hardware/lib/hardware/model/motherboard_slot.ex
+++ b/apps/hardware/lib/hardware/model/motherboard_slot.ex
@@ -81,7 +81,7 @@ defmodule Helix.Hardware.Model.MotherboardSlot do
     if get_field(changeset, :slot_id) do
       changeset
     else
-      pk = PK.generate([0x0003, 0x0002, 0x0000])
+      pk = PK.pk_for(__MODULE__)
       cast(changeset, %{slot_id: pk}, [:slot_id])
     end
   end

--- a/apps/hardware/lib/hardware/model/network_connection.ex
+++ b/apps/hardware/lib/hardware/model/network_connection.ex
@@ -19,6 +19,7 @@ defmodule Helix.Hardware.Model.NetworkConnection do
   @one_ip_per_network_index :network_connections_network_id_ip_unique_index
 
   @primary_key false
+  @ecto_autogenerate {:network_conections, {PK, :pk_for, [__MODULE__]}}
   schema "network_connections" do
     field :network_connection_id, PK,
       primary_key: true
@@ -42,7 +43,6 @@ defmodule Helix.Hardware.Model.NetworkConnection do
     |> cast(params, [:network_id])
     |> put_change(:ip, IPv4.autogenerate())
     |> changeset(params)
-    |> put_primary_key()
   end
 
   @spec update_changeset(t | Ecto.Changeset.t, %{}) :: Ecto.Changeset.t
@@ -57,12 +57,5 @@ defmodule Helix.Hardware.Model.NetworkConnection do
     |> validate_number(:downlink, greater_than_or_equal_to: 0)
     |> validate_number(:uplink, greater_than_or_equal_to: 0)
     |> unique_constraint(:ip, name: @one_ip_per_network_index)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    pk = PK.generate([0x0003, 0x0003, 0x0000])
-
-    put_change(changeset, :network_connection_id, pk)
   end
 end

--- a/apps/hardware/lib/hardware/model/network_connection.ex
+++ b/apps/hardware/lib/hardware/model/network_connection.ex
@@ -19,7 +19,7 @@ defmodule Helix.Hardware.Model.NetworkConnection do
   @one_ip_per_network_index :network_connections_network_id_ip_unique_index
 
   @primary_key false
-  @ecto_autogenerate {:network_conections, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:network_conection_id, {PK, :pk_for, [__MODULE__]}}
   schema "network_connections" do
     field :network_connection_id, PK,
       primary_key: true

--- a/apps/hell/lib/hell/ip/header.ex
+++ b/apps/hell/lib/hell/ip/header.ex
@@ -7,6 +7,9 @@ defmodule HELL.IPv6.Header do
     # Account
     Helix.Account.Model.Account                    => [0x0000],
 
+    # Entity
+    Helix.Entity.Model.Entity                      => [],
+
     # Server
     Helix.Server.Model.Server                      => [0x0002],
 

--- a/apps/hell/lib/hell/ip/header.ex
+++ b/apps/hell/lib/hell/ip/header.ex
@@ -1,7 +1,4 @@
 defmodule HELL.IPv6.Header do
-  @moduledoc """
-  Primary key generator for named modules, usually used with `Ecto` schemas.
-  """
 
   @mappings %{
     # Account
@@ -43,11 +40,11 @@ defmodule HELL.IPv6.Header do
     Helix.Log.Model.Revision                       => [0x0008, 0x0001]
   }
 
-  @doc """
-  Generates a PK for given module with a proper header, raises `RuntimeError`
-  when no header is available for the module.
-  """
   @spec pk_for(module) :: HELL.PK.t
+  @doc """
+  Generates a PK for given module with a proper header, raises
+  `FunctionClauseError` when no header is available for the module.
+  """
   for {module, header} <- @mappings do
     def pk_for(unquote(module)),
       do: HELL.IPv6.generate(unquote(header))

--- a/apps/hell/lib/hell/ip/header.ex
+++ b/apps/hell/lib/hell/ip/header.ex
@@ -47,9 +47,6 @@ defmodule HELL.IPv6.Header do
   @spec pk_for(module) :: HELL.PK.t
   for {module, header} <- @mappings do
     def pk_for(unquote(module)),
-      do: HELL.PK.generate(unquote(header))
+      do: HELL.IPv6.generate(unquote(header))
   end
-
-  def pk_for(m),
-    do: raise RuntimeError, "primary key not available for #{m} module"
 end

--- a/apps/hell/lib/hell/ip/header.ex
+++ b/apps/hell/lib/hell/ip/header.ex
@@ -1,0 +1,55 @@
+defmodule HELL.IPv6.Header do
+  @moduledoc """
+  Primary key generator for named modules, usually used with `Ecto` schemas.
+  """
+
+  @mappings %{
+    # Account
+    Helix.Account.Model.Account                    => [0x0000],
+
+    # Server
+    Helix.Server.Model.Server                      => [0x0002],
+
+    # Hardware
+    Helix.Hardware.Model.Component                 => [0x0003, 0x0001],
+    Helix.Hardware.Model.Motherboard               => [0x0003, 0x0001, 0x0000],
+    Helix.Hardware.Model.Component.HDD             => [0x0003, 0x0001, 0x0001],
+    Helix.Hardware.Model.Component.CPU             => [0x0003, 0x0001, 0x0002],
+    Helix.Hardware.Model.Component.RAM             => [0x0003, 0x0001, 0x0003],
+    Helix.Hardware.Model.Component.NIC             => [0x0003, 0x0001, 0x0004],
+    Helix.Hardware.Model.MotherboardSlot           => [0x0003, 0x0002],
+    Helix.Hardware.Model.NetworkConnection         => [0x0003, 0x0003],
+
+    # Sofware
+    Helix.Software.Model.File                      => [0x0004, 0x0000],
+    Helix.Software.Model.Storage                   => [0x0004, 0x0001],
+    Helix.Software.Model.StorageDrive              => [0x0004, 0x0001, 0x0001],
+    Helix.Software.Model.ModuleRole                => [0x0004, 0x0002],
+
+    # Process
+    Helix.Process.Model.Process                    => [0x0005, 0x0000],
+
+    # NPC
+    Helix.NPC.Model.NPC                            => [0x0006],
+
+    # Clan
+    Helix.Clan.Model.Clan                          => [0x0007],
+
+    # Log
+    Helix.Log.Model.Log                            => [0x0008, 0x0000],
+    Helix.Log.Model.Revision                       => [0x0008, 0x0001]
+  }
+
+  @doc """
+  Generates a PK for given module with a proper header, raises `RuntimeError`
+  when no header is available for the module.
+  """
+  @spec pk_for(module) :: HELL.PK.t
+  for {module, header} <- @mappings do
+    def pk_for(unquote(module)),
+      do: HELL.PK.generate(unquote(header))
+  end
+
+  def pk_for(m),
+    do: raise RuntimeError, "primary key not available for #{m} module"
+end

--- a/apps/hell/lib/hell/pk.ex
+++ b/apps/hell/lib/hell/pk.ex
@@ -4,10 +4,6 @@ defmodule HELL.PK do
 
   @behaviour Ecto.Type
 
-  @spec generate([non_neg_integer]) :: t
-  defdelegate generate(params),
-    to: HELL.IPv6
-
   @spec pk_for(module) :: t
   defdelegate pk_for(module),
     to: HELL.IPv6.Header

--- a/apps/hell/lib/hell/pk.ex
+++ b/apps/hell/lib/hell/pk.ex
@@ -4,33 +4,13 @@ defmodule HELL.PK do
 
   @behaviour Ecto.Type
 
-  # PK namespaces being used
-  # 0x0000  *       *       -> [Account]
-  # 0x0002  *       *       -> [Server]
-  # 0x0003  *       *       -> [Hardware]
-  #         0x0001  *         -> Component
-  #         *       0x0000      -> Motherboard
-  #         *       0x0001      -> HDD
-  #         *       0x0002      -> CPU
-  #         *       0x0003      -> RAM
-  #         *       0x0004      -> NIC
-  #         0x0002  *         -> MotherboardSlot
-  #         0x0003  *         -> NetworkConnection
-  # 0x0004  *       *       -> [Software]
-  #         0x0000  *         -> File
-  #         0x0001  *         -> Storage
-  #         *       0x0001      -> StorageDrive
-  #         0x0002  *         -> ModuleRole
-  # 0x0005  *       *       -> [Process]
-  # *       0x0000  *         -> Process
-  # 0x0006  *       *       -> [NPC]
-  # 0x0007  *       *       -> [Clan]
-  # 0x0008  *       *       -> [Log]
-  #         0x0000  *         -> Log
-  #         0x0001  *         -> Revision
   @spec generate([non_neg_integer]) :: t
   defdelegate generate(params),
     to: HELL.IPv6
+
+  @spec pk_for(module) :: t
+  defdelegate pk_for(module),
+    to: HELL.IPv6.Header
 
   def type,
     do: :inet

--- a/apps/log/lib/log/model/log.ex
+++ b/apps/log/lib/log/model/log.ex
@@ -61,7 +61,7 @@ defmodule Helix.Log.Model.Log do
     %__MODULE__{}
     |> cast(params, @creation_fields)
     |> validate_required(@required_fields)
-    |> put_primary_key()
+    |> put_change(:log_id, PK.pk_for(__MODULE__))
     |> prepare_changes(fn changeset ->
       revisions = [
         %{
@@ -86,16 +86,6 @@ defmodule Helix.Log.Model.Log do
     |> cast(params, @update_fields)
     |> validate_required(@required_fields)
     |> validate_number(:crypto_version, greater_than: 0)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    if get_field(changeset, :log_id) do
-      changeset
-    else
-      pk = PK.generate([0x0008, 0x0000, 0x0000])
-      cast(changeset, %{log_id: pk}, [:log_id])
-    end
   end
 
   defmodule Query do

--- a/apps/log/lib/log/model/log.ex
+++ b/apps/log/lib/log/model/log.ex
@@ -37,6 +37,7 @@ defmodule Helix.Log.Model.Log do
   @required_fields ~w/server_id entity_id message/a
 
   @primary_key false
+  @ecto_autogenerate {:log_id, {PK, :pk_for, [__MODULE__]}}
   schema "logs" do
     field :log_id, PK,
       primary_key: true
@@ -61,11 +62,9 @@ defmodule Helix.Log.Model.Log do
     %__MODULE__{}
     |> cast(params, @creation_fields)
     |> validate_required(@required_fields)
-    |> put_change(:log_id, PK.pk_for(__MODULE__))
     |> prepare_changes(fn changeset ->
       revisions = [
         %{
-          log_id: get_field(changeset, :log_id),
           entity_id: params[:entity_id],
           message: params[:message],
           forge_version: params[:forge_version]

--- a/apps/log/lib/log/model/revision.ex
+++ b/apps/log/lib/log/model/revision.ex
@@ -11,6 +11,7 @@ defmodule Helix.Log.Model.Revision do
   @creation_fields ~w/entity_id message forge_version log_id/a
 
   @primary_key false
+  @ecto_autogenerate {:revision_id, {PK, :pk_for, [__MODULE__]}}
   schema "revisions" do
     field :revision_id, PK,
       primary_key: true
@@ -29,9 +30,8 @@ defmodule Helix.Log.Model.Revision do
   def create_changeset(params) do
     %__MODULE__{}
     |> cast(params, @creation_fields)
-    |> validate_required([:entity_id, :message, :log_id])
+    |> validate_required([:entity_id, :message])
     |> validate_number(:forge_version, greater_than: 0)
-    |> put_primary_key()
     |> prepare_changes(fn changeset ->
       # REVIEW: This callback is executed even if this is the revision that
       #   created the log entry
@@ -53,15 +53,5 @@ defmodule Helix.Log.Model.Revision do
 
       changeset
     end)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    if get_field(changeset, :revision_id) do
-      changeset
-    else
-      pk = PK.pk_for(__MODULE__)
-      cast(changeset, %{revision_id: pk}, [:revision_id])
-    end
   end
 end

--- a/apps/log/lib/log/model/revision.ex
+++ b/apps/log/lib/log/model/revision.ex
@@ -60,7 +60,7 @@ defmodule Helix.Log.Model.Revision do
     if get_field(changeset, :revision_id) do
       changeset
     else
-      pk = PK.generate([0x0008, 0x0001, 0x0000])
+      pk = PK.pk_for(__MODULE__)
       cast(changeset, %{revision_id: pk}, [:revision_id])
     end
   end

--- a/apps/npc/lib/npc/model/npc.ex
+++ b/apps/npc/lib/npc/model/npc.ex
@@ -15,6 +15,7 @@ defmodule Helix.NPC.Model.NPC do
   @creation_fields ~w//a
 
   @primary_key false
+  @ecto_autogenerate {:npc_id, {PK, :pk_for, [__MODULE__]}}
   schema "npcs" do
     field :npc_id, HELL.PK,
       primary_key: true
@@ -26,14 +27,5 @@ defmodule Helix.NPC.Model.NPC do
   def create_changeset(params) do
     %__MODULE__{}
     |> cast(params, @creation_fields)
-    |> put_primary_key()
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    ip = PK.generate([0x0006, 0x0000, 0x0000])
-
-    changeset
-    |> cast(%{npc_id: ip}, [:npc_id])
   end
 end

--- a/apps/npc/test/controller/npc_test.exs
+++ b/apps/npc/test/controller/npc_test.exs
@@ -4,6 +4,7 @@ defmodule Helix.NPC.Controller.NPCTest do
 
   alias HELL.PK
   alias Helix.NPC.Controller.NPC, as: NPCController
+  alias Helix.NPC.Model.NPC, as: NPC
 
   test "create/1" do
     assert {:ok, _} = NPCController.create(%{})
@@ -16,7 +17,7 @@ defmodule Helix.NPC.Controller.NPCTest do
     end
 
     test "failure" do
-      assert {:error, :notfound} == NPCController.find(PK.generate([]))
+      assert {:error, :notfound} == NPCController.find(PK.pk_for(NPC))
     end
   end
 

--- a/apps/process/lib/process/model/process.ex
+++ b/apps/process/lib/process/model/process.ex
@@ -39,6 +39,7 @@ defmodule Helix.Process.Model.Process do
   @opaque id :: PK.t
 
   @primary_key false
+  @ecto_autogenerate {:process_id, {PK, :pk_for, [__MODULE__]}}
   schema "processes" do
     field :process_id, PK,
       primary_key: true
@@ -128,7 +129,6 @@ defmodule Helix.Process.Model.Process do
         do: [],
         else: [process_data: "invalid value"]
     end)
-    |> put_primary_key()
     |> put_defaults()
     |> changeset(params)
     |> server_to_process_map()
@@ -372,11 +372,6 @@ defmodule Helix.Process.Model.Process do
 
       objective_allows?.(resource) and limitations > allocated
     end)
-  end
-
-  @spec put_primary_key(Changeset.t) :: Changeset.t
-  defp put_primary_key(changeset) do
-    put_change(changeset, :process_id, PK.generate([0x0005, 0x0000, 0x0000]))
   end
 
   @spec put_defaults(Changeset.t) :: Changeset.t

--- a/apps/process/test/controller/process_test.exs
+++ b/apps/process/test/controller/process_test.exs
@@ -3,6 +3,7 @@ defmodule Helix.Process.Controller.ProcessTest do
 
   alias HELL.PK
   alias Helix.Process.Controller.Process, as: ProcessController
+  alias Helix.Process.Model.Process, as: ProcessModel
 
   @tag :pending
   test "create/1" do
@@ -18,7 +19,8 @@ defmodule Helix.Process.Controller.ProcessTest do
 
     @tag :pending
     test "failure" do
-      assert {:error, :notfound} = ProcessController.find(PK.generate([]))
+      assert {:error, :notfound} =
+        ProcessController.find(PK.pk_for(ProcessModel))
     end
   end
 

--- a/apps/server/lib/server/model/server.ex
+++ b/apps/server/lib/server/model/server.ex
@@ -30,6 +30,7 @@ defmodule Helix.Server.Model.Server do
   @update_fields ~w/poi_id motherboard_id/a
 
   @primary_key false
+  @ecto_autogenerate {:server_id, {PK, :pk_for, [__MODULE__]}}
   schema "servers" do
     field :server_id, HELL.PK,
       primary_key: true
@@ -48,20 +49,11 @@ defmodule Helix.Server.Model.Server do
     %__MODULE__{}
     |> cast(params, @creation_fields)
     |> validate_required(:server_type)
-    |> put_primary_key()
   end
 
   @spec update_changeset(t | Ecto.Changeset.t, update_params) :: Ecto.Changeset.t
   def update_changeset(struct, params) do
     struct
     |> cast(params, @update_fields)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    ip = PK.generate([0x0002, 0x0000, 0x0000])
-
-    changeset
-    |> cast(%{server_id: ip}, [:server_id])
   end
 end

--- a/apps/software/lib/software/model/file.ex
+++ b/apps/software/lib/software/model/file.ex
@@ -40,6 +40,7 @@ defmodule Helix.Software.Model.File do
   @update_fields ~w/name file_path storage_id/a
 
   @primary_key false
+  @ecto_autogenerate {:file_id, {PK, :pk_for, [__MODULE__]}}
   schema "files" do
     field :file_id, HELL.PK,
       primary_key: true
@@ -65,7 +66,6 @@ defmodule Helix.Software.Model.File do
     %__MODULE__{}
     |> cast(params, @creation_fields)
     |> generic_validations()
-    |> put_primary_key()
   end
 
   @spec update_changeset(t | Ecto.Changeset.t, update_params) :: Ecto.Changeset.t
@@ -82,15 +82,5 @@ defmodule Helix.Software.Model.File do
       [:name, :file_path, :file_size, :file_type, :storage_id])
     |> validate_number(:file_size, greater_than: 0)
     |> unique_constraint(:file_path, name: :unique_file_path_index)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    if get_field(changeset, :file_id) do
-      changeset
-    else
-      pk = PK.pk_for(__MODULE__)
-      put_change(changeset, :file_id, pk)
-    end
   end
 end

--- a/apps/software/lib/software/model/file.ex
+++ b/apps/software/lib/software/model/file.ex
@@ -89,7 +89,7 @@ defmodule Helix.Software.Model.File do
     if get_field(changeset, :file_id) do
       changeset
     else
-      pk = PK.generate([0x0004, 0x0000, 0x0000])
+      pk = PK.pk_for(__MODULE__)
       put_change(changeset, :file_id, pk)
     end
   end

--- a/apps/software/lib/software/model/module_role.ex
+++ b/apps/software/lib/software/model/module_role.ex
@@ -16,6 +16,7 @@ defmodule Helix.Software.Model.ModuleRole do
   @creation_fields ~w/file_type module_role/a
 
   @primary_key false
+  @ecto_autogenerate {:module_role_id, {PK, :pk_for, [__MODULE__]}}
   schema "module_roles" do
     field :module_role_id, HELL.PK,
       primary_key: true
@@ -35,15 +36,6 @@ defmodule Helix.Software.Model.ModuleRole do
     |> cast(params, @creation_fields)
     |> validate_required([:module_role, :file_type])
     |> unique_constraint(:module_role, name: :file_type_module_role_unique_constraint)
-    |> put_primary_key()
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    pk = PK.generate([0x0004, 0x0002, 0x0000])
-
-    changeset
-    |> cast(%{module_role_id: pk}, [:module_role_id])
   end
 
   defmodule Query do

--- a/apps/software/lib/software/model/storage.ex
+++ b/apps/software/lib/software/model/storage.ex
@@ -28,7 +28,7 @@ defmodule Helix.Software.Model.Storage do
       references: :storage_id
   end
 
-  @spec create_changeset(map) :: Ecto.Changeset.t
-  def create_changeset(params \\ %{}),
-    do: cast(%__MODULE__{}, params, [:storage_id])
+  @spec create_changeset() :: Ecto.Changeset.t
+  def create_changeset,
+    do: cast(%__MODULE__{}, %{}, [])
 end

--- a/apps/software/lib/software/model/storage.ex
+++ b/apps/software/lib/software/model/storage.ex
@@ -39,7 +39,7 @@ defmodule Helix.Software.Model.Storage do
     if get_field(changeset, :storage_id) do
       changeset
     else
-      pk = PK.generate([0x0004, 0x0001, 0x0000])
+      pk = PK.pk_for(__MODULE__)
       put_change(changeset, :storage_id, pk)
     end
   end

--- a/apps/software/lib/software/model/storage.ex
+++ b/apps/software/lib/software/model/storage.ex
@@ -15,6 +15,7 @@ defmodule Helix.Software.Model.Storage do
   }
 
   @primary_key false
+  @ecto_autogenerate {:storage_id, {PK, :pk_for, [__MODULE__]}}
   schema "storages" do
     field :storage_id, HELL.PK,
       primary_key: true
@@ -28,19 +29,6 @@ defmodule Helix.Software.Model.Storage do
   end
 
   @spec create_changeset() :: Ecto.Changeset.t
-  def create_changeset do
-    %__MODULE__{}
-    |> cast(%{}, [])
-    |> put_primary_key()
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    if get_field(changeset, :storage_id) do
-      changeset
-    else
-      pk = PK.pk_for(__MODULE__)
-      put_change(changeset, :storage_id, pk)
-    end
-  end
+  def create_changeset,
+    do: cast(%__MODULE__{}, %{}, [])
 end

--- a/apps/software/lib/software/model/storage.ex
+++ b/apps/software/lib/software/model/storage.ex
@@ -28,7 +28,7 @@ defmodule Helix.Software.Model.Storage do
       references: :storage_id
   end
 
-  @spec create_changeset() :: Ecto.Changeset.t
-  def create_changeset,
-    do: cast(%__MODULE__{}, %{}, [])
+  @spec create_changeset(map) :: Ecto.Changeset.t
+  def create_changeset(params \\ %{}),
+    do: cast(%__MODULE__{}, params, [:storage_id])
 end

--- a/apps/software/lib/software/model/storage_drive.ex
+++ b/apps/software/lib/software/model/storage_drive.ex
@@ -42,7 +42,7 @@ defmodule Helix.Software.Model.StorageDrive do
     if get_field(changeset, :drive_id) do
       changeset
     else
-      pk = PK.generate([0x0004, 0x0001, 0x0001])
+      pk = PK.pk_for(__MODULE__)
       put_change(changeset, :drive_id, pk)
     end
   end

--- a/apps/software/lib/software/model/storage_drive.ex
+++ b/apps/software/lib/software/model/storage_drive.ex
@@ -16,6 +16,7 @@ defmodule Helix.Software.Model.StorageDrive do
   @creation_fields ~w/storage_id/a
 
   @primary_key false
+  @ecto_autogenerate {:drive_id, {PK, :pk_for, [__MODULE__]}}
   schema "storage_drives" do
     field :storage_id, PK,
       primary_key: true
@@ -33,17 +34,6 @@ defmodule Helix.Software.Model.StorageDrive do
   def create_changeset(params) do
     %__MODULE__{}
     |> cast(params, @creation_fields)
-    |> put_primary_key()
     |> validate_required(@creation_fields)
-  end
-
-  @spec put_primary_key(Ecto.Changeset.t) :: Ecto.Changeset.t
-  defp put_primary_key(changeset) do
-    if get_field(changeset, :drive_id) do
-      changeset
-    else
-      pk = PK.pk_for(__MODULE__)
-      put_change(changeset, :drive_id, pk)
-    end
   end
 end

--- a/apps/software/lib/software/model/storage_drive.ex
+++ b/apps/software/lib/software/model/storage_drive.ex
@@ -13,10 +13,14 @@ defmodule Helix.Software.Model.StorageDrive do
     drive_id: PK.t
   }
 
-  @creation_fields ~w/storage_id/a
+  @type creation_params :: %{
+    storage_id: PK.t,
+    drive_id: PK.t
+  }
+
+  @creation_fields ~w/storage_id drive_id/a
 
   @primary_key false
-  @ecto_autogenerate {:drive_id, {PK, :pk_for, [__MODULE__]}}
   schema "storage_drives" do
     field :storage_id, PK,
       primary_key: true
@@ -30,7 +34,7 @@ defmodule Helix.Software.Model.StorageDrive do
       define_field: false
   end
 
-  @spec create_changeset(%{storage_id: PK.t}) :: Ecto.Changeset.t
+  @spec create_changeset(creation_params) :: Ecto.Changeset.t
   def create_changeset(params) do
     %__MODULE__{}
     |> cast(params, @creation_fields)

--- a/apps/software/test/support/factory.ex
+++ b/apps/software/test/support/factory.ex
@@ -4,6 +4,8 @@ defmodule Helix.Software.Factory do
 
   alias HELL.PK
   alias HELL.TestHelper.Random
+  alias Helix.Software.Model.Storage
+  alias Helix.Software.Model.File
 
   def file_factory do
     :file
@@ -19,7 +21,7 @@ defmodule Helix.Software.Factory do
   end
 
   def storage_factory do
-    pk = PK.generate([0x0004, 0x0001, 0x0000])
+    pk = PK.pk_for(Storage)
 
     files = Random.repeat(1..3, fn ->
       :file
@@ -48,7 +50,7 @@ defmodule Helix.Software.Factory do
     size = Burette.Number.number(1024..1_048_576)
 
     %Helix.Software.Model.File{
-      file_id: PK.generate([0x0004, 0x0000, 0x0000]),
+      file_id: PK.pk_for(File),
       name: Burette.Color.name(),
       file_path: path,
       file_size: size,

--- a/apps/software/test/support/factory.ex
+++ b/apps/software/test/support/factory.ex
@@ -4,7 +4,8 @@ defmodule Helix.Software.Factory do
 
   alias HELL.PK
   alias HELL.TestHelper.Random
-  alias Helix.Software.Model.Storage
+  alias Helix.Hardware.Model.Component
+  alias Helix.Software.Model.StorageDrive
   alias Helix.Software.Model.File
 
   def file_factory do
@@ -21,20 +22,12 @@ defmodule Helix.Software.Factory do
   end
 
   def storage_factory do
-    pk = PK.pk_for(Storage)
-
-    files = Random.repeat(1..3, fn ->
-      :file
-      |> prepare()
-      |> Map.put(:storage_id, pk)
-    end)
-
+    files = Random.repeat(1..3, fn -> prepare(:file) end)
     drives = Random.repeat(1..3, fn ->
-      Helix.Software.Model.StorageDrive.create_changeset(%{storage_id: pk})
+      %StorageDrive{drive_id: PK.pk_for(Component)}
     end)
 
     %Helix.Software.Model.Storage{
-      storage_id: pk,
       files: files,
       drives: drives
     }

--- a/apps/software/test/support/factory.ex
+++ b/apps/software/test/support/factory.ex
@@ -6,7 +6,6 @@ defmodule Helix.Software.Factory do
   alias HELL.TestHelper.Random
   alias Helix.Hardware.Model.Component
   alias Helix.Software.Model.StorageDrive
-  alias Helix.Software.Model.File
 
   def file_factory do
     :file
@@ -43,7 +42,6 @@ defmodule Helix.Software.Factory do
     size = Burette.Number.number(1024..1_048_576)
 
     %Helix.Software.Model.File{
-      file_id: PK.pk_for(File),
       name: Burette.Color.name(),
       file_path: path,
       file_size: size,


### PR DESCRIPTION
Fixes #7

Reasoning for some decisions:

- The `Header` module is located on `IPv6` because it knows implementation details of how `PK` generation works (better said: it knows that the generated `PK` is `IPv6`)
- `@mappings` map format is that way to keep it readable while reducing the need to edit it (this is why there's so many useless whitespaces).

Couple things to discuss:

- `@mappings` and `HELL.IPv6.Header` are ugly names, I'm accepting suggestions on that.
- The map format might not be ideal, I'm not sure if this formatting is okay, I just did what made sense.
- Many models aren't using auto generation, this is 'cause I found it hard to do so, auto generation is lazy and sometimes we need PK access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/17)
<!-- Reviewable:end -->
