### PR TITLE
Fix Account fetch/find conventions.

### DIFF
--- a/apps/helix_account/lib/account/controller/account.ex
+++ b/apps/helix_account/lib/account/controller/account.ex
@@ -7,9 +7,6 @@ defmodule Helix.Account.Controller.Account do
 
   import Ecto.Query, only: [select: 3]
 
-  @type find_params :: [find_param]
-  @type find_param :: {:email, Account.email} | {:username, Account.username}
-
   @spec create(Account.creation_params) ::
     {:ok, Account.t} | {:error, Ecto.Changeset.t}
   def create(params) do
@@ -18,32 +15,17 @@ defmodule Helix.Account.Controller.Account do
     |> Repo.insert()
   end
 
+  @spec fetch(Account.id) :: Account.t | nil
+  def fetch(account_id),
+    do: Repo.get(Account, account_id)
+
+  @spec fetch_by_email(Account.email) :: Account.t | nil
+  def fetch_by_email(email),
+    do: Repo.get_by(Account, email: String.downcase(email))
+
   @spec fetch_by_username(Account.username) :: Account.t | nil
   def fetch_by_username(username),
     do: Repo.get_by(Account, username: String.downcase(username))
-
-  @spec find(Account.id) :: {:ok, Account.t} | {:error, :notfound}
-  def find(account_id) do
-    case Repo.get_by(Account, account_id: account_id) do
-      nil ->
-        {:error, :notfound}
-      account ->
-        {:ok, account}
-    end
-  end
-
-  @spec find_by(find_params) :: [Account.t]
-  def find_by(params) do
-    query = Enum.reduce(params, Account, &reduce_find_params/2)
-
-    Repo.all(query)
-  end
-
-  @spec reduce_find_params(find_param, Ecto.Queryable.t) :: Ecto.Queryable.t
-  defp reduce_find_params({:email, email}, query),
-    do: Account.Query.by_email(query, email)
-  defp reduce_find_params({:username, username}, query),
-    do: Account.Query.by_username(query, username)
 
   @spec update(Account.t, Account.update_params) ::
     {:ok, Account.t} | {:error, Ecto.Changeset.t}

--- a/apps/helix_account/lib/account/model/session.ex
+++ b/apps/helix_account/lib/account/model/session.ex
@@ -2,6 +2,7 @@ defmodule Helix.Account.Model.SessionSerializer do
 
   @behaviour Guardian.Serializer
 
+  alias Helix.Account.Controller.Account, as: AccountController
   alias Helix.Account.Model.Account
 
   @opaque session :: String.t
@@ -18,6 +19,12 @@ defmodule Helix.Account.Model.SessionSerializer do
   # if it depends on external data, but let's leave it as is until we fix it
   @spec from_token(session) :: {:ok, Account.t}
   def from_token(account_id) do
-    Helix.Account.Controller.Account.find(account_id)
+    case AccountController.fetch(account_id) do
+      nil ->
+        # FIXME: use a better error message
+        {:error, "notfound"}
+      account ->
+        {:ok, account}
+    end
   end
 end

--- a/apps/helix_account/test/controller/account_test.exs
+++ b/apps/helix_account/test/controller/account_test.exs
@@ -14,7 +14,7 @@ defmodule Helix.Account.Controller.AccountTest do
 
   @moduletag :integration
 
-  describe "account creation" do
+  describe "creation" do
     test "succeeds with valid params" do
       params = Factory.params_for(:account)
 
@@ -45,32 +45,34 @@ defmodule Helix.Account.Controller.AccountTest do
     end
   end
 
-  describe "account fetching" do
+  describe "fetching" do
     test "succeeds by id" do
       account = Factory.insert(:account)
-      assert {:ok, _} = AccountController.find(account.account_id)
+      assert %Account{} = AccountController.fetch(account.account_id)
     end
 
     test "succeeds by email" do
       account = Factory.insert(:account)
-      assert [_] = AccountController.find_by(email: account.email)
+      assert %Account{} = AccountController.fetch_by_email(account.email)
     end
 
     test "succeeds by username" do
       account = Factory.insert(:account)
-      assert [_] = AccountController.find_by(username: account.username)
+      assert %Account{} = AccountController.fetch_by_username(account.username)
     end
 
-    test "returns empty list when email isn't in use" do
-      assert [] == AccountController.find_by(email: "a@bc.com")
+    test "fails when account with id doesn't exist" do
+      refute AccountController.fetch(Random.pk())
     end
 
-    test "returns empty list when username isn't in use" do
-      assert [] == AccountController.find_by(username: "abcdef")
+    test "fails when account with email doesn't exist" do
+      bogus = Factory.build(:account)
+      refute AccountController.fetch_by_email(bogus.email)
     end
 
-    test "fails when account doesn't exist" do
-      assert {:error, :notfound} == AccountController.find(Random.pk())
+    test "fails when account with username doesn't exist" do
+      bogus = Factory.build(:account)
+      refute AccountController.fetch_by_username(bogus.username)
     end
   end
 


### PR DESCRIPTION
Remove:

- `AccountController.find/1`
- `AccountController.find_by/1`

Add:

- `AccountController.fetch/1`
- `AccountController.fetch_by_email/1`
- `AccountController.fetch_by_username/1`

Change:

- Update tests.
- Updates `Session` model as it was using the `find` API.

Reasoning: email and username are also identities of an `Account`, so they must be fetch operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/62)
<!-- Reviewable:end -->
