### PR TITLE
CryptoKey implementation

### DIFF
--- a/apps/helix_software/lib/software/controller/crypto_key.ex
+++ b/apps/helix_software/lib/software/controller/crypto_key.ex
@@ -1,0 +1,57 @@
+defmodule Helix.Software.Controller.CryptoKey do
+
+  alias Helix.Software.Model.CryptoKey
+  alias Helix.Software.Model.File
+  alias Helix.Software.Model.Storage
+  alias Helix.Software.Repo
+
+  import Ecto.Query, only: [select: 3]
+
+  @spec create(Storage.t, HELL.PK.t, File.t) ::
+    {:ok, CryptoKey.t} | {:error, Ecto.Changeset.t}
+  @doc """
+  Creates a key on `storage` to decrypt `target_file` that is on `server_id`
+  """
+  def create(storage, server_id, target_file) do
+    storage
+    |> CryptoKey.create(server_id, target_file)
+    |> Repo.insert()
+  end
+
+  @spec fetch!(File.t | File.id) :: CryptoKey.t | nil
+  @doc """
+  Fetches a key by their id or their file
+  """
+  def fetch!(%File{file_id: id}),
+    do: fetch!(id)
+  def fetch!(id),
+    do: Repo.get!(CryptoKey, id)
+
+  @spec get_on_storage(Storage.t) :: [CryptoKey.t]
+  @doc """
+  Gets the keys on `storage`
+  """
+  def get_on_storage(storage) do
+    storage
+    |> CryptoKey.Query.from_storage()
+    |> Repo.all()
+  end
+
+  @spec get_files_targeted_on_storage(Storage.t, Storage.t) :: [HELL.PK.t]
+  @doc """
+  Returns the id of all files on `target_storage` for whom there is a key on
+  `origin_storage`
+
+  ## Example
+
+      iex> get_files_targeted_on_storage(%Storage{}, %Storage{})
+      ["aa::bb", "cc::dd"]
+  """
+  def get_files_targeted_on_storage(origin_storage, target_storage) do
+    origin_storage
+    |> CryptoKey.Query.from_storage()
+    |> CryptoKey.Query.target_files_on_storage(target_storage)
+    |> select([k], k.target_file_id)
+    |> Repo.all()
+  end
+end

--- a/apps/helix_software/lib/software/model/crypto_key.ex
+++ b/apps/helix_software/lib/software/model/crypto_key.ex
@@ -1,0 +1,93 @@
+defmodule Helix.Software.Model.CryptoKey do
+
+  use Ecto.Schema
+
+  alias Helix.Software.Model.File
+  alias Helix.Software.Model.Storage
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+    file_id: HELL.PK.t,
+    target_file_id: HELL.PK.t | nil,
+    target_server_id: HELL.PK.t
+  }
+
+  @default_path "/.keys"
+  @software_type "crypto_key"
+
+  @primary_key false
+  schema "crypto_keys" do
+    field :file_id, HELL.PK,
+      primary_key: true
+
+    field :target_file_id, HELL.PK
+    field :target_server_id, HELL.PK
+
+    belongs_to :file, File,
+      foreign_key: :file_id,
+      references: :file_id,
+      define_field: false
+
+    belongs_to :target_file, File,
+      foreign_key: :target_file_id,
+      references: :file_id,
+      define_field: false
+  end
+
+  @spec create(Storage.t, HELL.PK.t, File.t) :: Ecto.Changeset.t
+  @doc """
+  Creates a key for `target_file` on `storage`.
+
+  `server_id` is the server that has `target_file` so we can inform the player
+  that the key is for a certain server in their hacked database
+  """
+  def create(storage = %Storage{}, server_id, target_file = %File{}) do
+    file = generate_file(storage)
+
+    %__MODULE__{}
+    |> cast(%{target_server_id: server_id}, [:target_server_id])
+    |> put_assoc(:target_file, target_file, required: true)
+    |> put_assoc(:file, file, required: true)
+    |> validate_required([:target_server_id])
+  end
+
+  defp generate_file(storage) do
+    params = %{
+      # FIXME: Use an apropriate
+      name: "Key #{Enum.random(1..100_000_000)}",
+      path: @default_path,
+      # REVIEW: Make keys actually have a size? If so we'd have to check if the
+      #   storage can store them tho
+      file_size: 1,
+      software_type: @software_type,
+    }
+
+    File.create(storage, params)
+  end
+
+  defmodule Query do
+
+    alias Ecto.Queryable
+
+    alias Helix.Software.Model.CryptoKey
+    alias Helix.Software.Model.File
+    alias Helix.Software.Model.Storage
+
+    import Ecto.Query, only: [join: 5, where: 3]
+
+    @spec from_storage(Queryable.t, Storage.t) :: Queryable.t
+    def from_storage(query \\ CryptoKey, %Storage{storage_id: id}) do
+      query
+      |> join(:inner, [k], f in File, k.file_id == f.file_id)
+      |> where([k, ..., f], f.storage_id == ^id)
+    end
+
+    @spec target_files_on_storage(Queryable.t, Storage.t) :: Queryable.t
+    def target_files_on_storage(query \\ CryptoKey, %Storage{storage_id: id}) do
+      query
+      |> join(:inner, [k], t in File, k.target_file_id == t.file_id)
+      |> where([k, ..., t], t.storage_id == ^id)
+    end
+  end
+end

--- a/apps/helix_software/lib/software/model/software_type.ex
+++ b/apps/helix_software/lib/software/model/software_type.ex
@@ -53,6 +53,10 @@ defmodule Helix.Software.Model.SoftwareType do
       "anymap" => %{
         extension: "map",
         modules: ["geo", "inbound", "outbound"]
+      },
+      "crypto_key" => %{
+        extension: "key",
+        modules: []
       }
     }
   end

--- a/apps/helix_software/priv/repo/migrations/20170329222739_add_crypto_key_software.exs
+++ b/apps/helix_software/priv/repo/migrations/20170329222739_add_crypto_key_software.exs
@@ -1,0 +1,23 @@
+defmodule Helix.Software.Repo.Migrations.AddCryptoKeySoftware do
+  use Ecto.Migration
+
+  def change do
+    create table(:crypto_keys, primary_key: false) do
+      add :file_id, references(:files, column: :file_id, type: :inet, on_delete: :delete_all), primary_key: true
+
+      # REVIEW: Maybe leave the `on_delete` as nothing and centralize file
+      #   delete to ensure that any table that has a soft link (like this one)
+      #   is nilified and events are emited if any
+      add :target_file_id, references(:files, column: :file_id, type: :inet, on_delete: :nilify_all)
+
+      add :target_server_id, :inet, null: false
+    end
+
+    alter table(:files) do
+      add :crypto_version, :integer
+    end
+
+    create index(:crypto_keys, [:target_file_id])
+    create index(:crypto_keys, [:target_server_id])
+  end
+end

--- a/apps/helix_software/test/controller/crypto_key_test.exs
+++ b/apps/helix_software/test/controller/crypto_key_test.exs
@@ -1,0 +1,26 @@
+defmodule Helix.Software.Controller.CryptoKeyTest do
+
+  use ExUnit.Case, async: true
+
+  alias HELL.TestHelper.Random
+  alias Helix.Software.Controller.CryptoKey, as: CryptoKeyController
+  alias Helix.Software.Controller.File, as: FileController
+
+  alias Helix.Software.Factory
+
+  describe "create/3" do
+    test "will create a file for the key on storage" do
+      storage = Factory.insert(:storage, %{files: []})
+      random_files = Factory.insert_list(5, :file, %{crypto_version: 1})
+      server_id = Random.pk()
+
+      create_key = &CryptoKeyController.create(storage, server_id, &1)
+      Enum.each(random_files, create_key)
+
+      files = FileController.get_files_on_target_storage(storage, storage)
+
+      assert 5 == Enum.count(files)
+      assert Enum.all?(files, &(&1.software_type == "crypto_key"))
+    end
+  end
+end

--- a/apps/helix_software/test/controller/file_test.exs
+++ b/apps/helix_software/test/controller/file_test.exs
@@ -4,6 +4,7 @@ defmodule Helix.Software.Controller.FileTest do
 
   alias HELL.TestHelper.Random
   alias Helix.Software.Controller.File, as: FileController
+  alias Helix.Software.Controller.CryptoKey, as: CryptoKeyController
   alias Helix.Software.Model.File
   alias Helix.Software.Model.SoftwareModule
   alias Helix.Software.Repo
@@ -56,6 +57,51 @@ defmodule Helix.Software.Controller.FileTest do
 
     test "returns nil if file doesn't exist" do
       refute FileController.fetch(Random.pk())
+    end
+  end
+
+  describe "get_files_on_target_storage/2" do
+    test "returns non-encrypted files" do
+      origin_storage = Factory.insert(:storage, %{files: []})
+      target_storage = Factory.insert(:storage, %{files: []})
+
+      Factory.insert_list(5, :file, %{storage: target_storage})
+      Factory.insert_list(5, :file, %{storage: target_storage, crypto_version: 1})
+
+      files = FileController.get_files_on_target_storage(
+        origin_storage,
+        target_storage)
+
+      assert 5 == Enum.count(files)
+      assert Enum.all?(files, &is_nil(&1.crypto_version))
+    end
+
+    test "returns additional files for which the origin storage has a key" do
+      origin_storage = Factory.insert(:storage, %{files: []})
+      target_storage = Factory.insert(:storage, %{files: []})
+      server_id = Random.pk()
+
+      Factory.insert_list(5, :file, %{storage: target_storage})
+      encrypted_files = Factory.insert_list(
+        5,
+        :file,
+        %{storage: target_storage, crypto_version: 1})
+
+      create_key = &CryptoKeyController.create(origin_storage, server_id, &1)
+      Enum.each(encrypted_files, create_key)
+
+      files = FileController.get_files_on_target_storage(
+        origin_storage,
+        target_storage)
+
+      unencrypted_returned_files = Enum.filter(
+        files,
+        &is_nil(&1.crypto_version))
+      encrypted_returned_files = Enum.filter(files, &(&1.crypto_version == 1))
+
+      assert 10 == Enum.count(files)
+      assert 5 == Enum.count(unencrypted_returned_files)
+      assert 5 == Enum.count(encrypted_returned_files)
     end
   end
 
@@ -126,7 +172,7 @@ defmodule Helix.Software.Controller.FileTest do
       file = Factory.insert(:file)
       path = Factory.params_for(:file).path
 
-      {:ok, file} = FileController.move(file, path, file.storage_id)
+      {:ok, file} = FileController.move(file, path)
 
       assert path == file.path
     end
@@ -136,7 +182,7 @@ defmodule Helix.Software.Controller.FileTest do
       similarities = Map.take(file0, [:name, :storage, :software_type])
       file1 = Factory.insert(:file, similarities)
 
-      result = FileController.move(file1, file0.path, file0.storage_id)
+      result = FileController.move(file1, file0.path)
       assert {:error, :file_exists} == result
     end
   end

--- a/apps/helix_software/test/model/crypto_key_test.exs
+++ b/apps/helix_software/test/model/crypto_key_test.exs
@@ -1,0 +1,24 @@
+defmodule Helix.Software.Model.CryptoKeyTest do
+
+  use ExUnit.Case, async: true
+
+  alias HELL.TestHelper.Random
+
+  alias Helix.Software.Model.CryptoKey
+  alias Helix.Software.Model.File
+  alias Helix.Software.Model.Storage
+
+  @moduletag :unit
+
+  describe "create/3" do
+    test "when provided with a storage, a server_id and a target file, succeeds" do
+      file = %File{}
+      storage = %Storage{}
+      server_id = Random.pk()
+
+      changeset = CryptoKey.create(storage, server_id, file)
+
+      assert changeset.valid?
+    end
+  end
+end


### PR DESCRIPTION
- Adds the `CryptoKey` model
- Adds a controller to create `CryptoKey` records, to fetch all from a storage and to get all from storage A that can be used for files on storage B
- Adds a function on file controller to fetch all files on storage B that are not encrypted or for whom a key exists on storage A
- Removed the `storage_id` param from file controller's move function as moving from a storage to another should be a transactional operation of `copy from A to B and delete from A` to avoid potential bugs
- Opted to start using more expressive function clauses for controllers and models (see crypto model's create/2 function). This not only would improve developer's experience but could reduce potential bugs thanks to type analysis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/80)
<!-- Reviewable:end -->
