### PR TITLE
Implement ProcessType for Encryptor and Decryptor

### DIFF
--- a/lib/software/model/software_type/decryptor/process_type.ex
+++ b/lib/software/model/software_type/decryptor/process_type.ex
@@ -1,30 +1,31 @@
-defmodule Helix.Software.Model.SoftwareType.Decryptor.ProcessType do
+# FIXME: OTP20
+defmodule Software.Decryptor.ProcessType do
 
   @enforce_keys [:storage_id, :target_file_id, :scope]
   defstruct [:storage_id, :target_file_id, :scope]
 
-  # defimpl Helix.Process.Model.Process.ProcessType do
+  defimpl Helix.Process.Model.Process.ProcessType do
 
-  #   alias Helix.Software.Model.SoftwareType.Decryptor.ProcessConclusionEvent
+    alias Helix.Software.Model.SoftwareType.Decryptor.ProcessConclusionEvent
 
-  #   # The only value that is dynamic (ie: the more allocated, the faster the
-  #   # process goes) is cpu
-  #   def dynamic_resources(%{}),
-  #     do: [:cpu]
+    # The only value that is dynamic (ie: the more allocated, the faster the
+    # process goes) is cpu
+    def dynamic_resources(%{}),
+      do: [:cpu]
 
-  #   def event(data, process, :completed) do
-  #     event = %ProcessConclusionEvent{
-  #       target_file_id: data.target_file_id,
-  #       target_server_id: process.target_server_id,
-  #       storage_id: data.storage_id,
-  #       scope: data.scope
-  #     }
+    def event(data, process, :completed) do
+      event = %ProcessConclusionEvent{
+        target_file_id: data.target_file_id,
+        target_server_id: process.target_server_id,
+        storage_id: data.storage_id,
+        scope: data.scope
+      }
 
-  #     [event]
-  #   end
+      [event]
+    end
 
-  #   def event(_, _, _) do
-  #     []
-  #   end
-  # end
+    def event(_, _, _) do
+      []
+    end
+  end
 end

--- a/lib/software/model/software_type/encryptor/process_type.ex
+++ b/lib/software/model/software_type/encryptor/process_type.ex
@@ -1,30 +1,31 @@
-defmodule Helix.Software.Model.SoftwareType.Encryptor.ProcessType do
+# FIXME: OTP20
+defmodule Software.Encryptor.ProcessType do
 
   @enforce_keys [:storage_id, :target_file_id, :version]
   defstruct [:storage_id, :target_file_id, :version]
 
-  # defimpl Helix.Process.Model.Process.ProcessType do
+  defimpl Helix.Process.Model.Process.ProcessType do
 
-  #   alias Helix.Software.Model.SoftwareType.Encryptor.ProcessConclusionEvent
+    alias Helix.Software.Model.SoftwareType.Encryptor.ProcessConclusionEvent
 
-  #   # The only value that is dynamic (ie: the more allocated, the faster the
-  #   # process goes) is cpu
-  #   def dynamic_resources(%{}),
-  #     do: [:cpu]
+    # The only value that is dynamic (ie: the more allocated, the faster the
+    # process goes) is cpu
+    def dynamic_resources(%{}),
+      do: [:cpu]
 
-  #   def event(data, process, :completed) do
-  #     event = %ProcessConclusionEvent{
-  #       target_file_id: data.target_file_id,
-  #       target_server_id: process.target_server_id,
-  #       storage_id: data.storage_id,
-  #       version: data.version
-  #     }
+    def event(data, process, :completed) do
+      event = %ProcessConclusionEvent{
+        target_file_id: data.target_file_id,
+        target_server_id: process.target_server_id,
+        storage_id: data.storage_id,
+        version: data.version
+      }
 
-  #     [event]
-  #   end
+      [event]
+    end
 
-  #   def event(_, _, _) do
-  #     []
-  #   end
-  # end
+    def event(_, _, _) do
+      []
+    end
+  end
 end


### PR DESCRIPTION
This was meant to go on #82 (as can be seen by the fact that it was pushed upstream commented) but errors were happening. Today, after debugging, i've found out that the reason was that the file name length of the beam file generated by the protocol was too long and erl_tar didn't liked it, as noted on #103 

This PR doesn't actually adds anything special, just enable the protocol implementation that was buggy before and, as soon as we give some more love to process again, it'll be testable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/104)
<!-- Reviewable:end -->
