### PR TITLE
Improve compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ erl_crash.dump
 
 # Macintosh
 *.DS_Store
+
+# xref graphs
+xref_graph.dot
+/graphs

--- a/config/account/config.exs
+++ b/config/account/config.exs
@@ -15,5 +15,3 @@ config :guardian, Guardian,
   allowed_algos: ["HS512"],
   allowed_drift: 2_000,
   serializer: Helix.Account.Controller.Session
-
-import_config "#{Mix.env}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,5 +16,6 @@ config :helix, :router_port, System.get_env("HELF_ROUTER_PORT") || 8080
 
 config :distillery, no_warn_missing: [:burette]
 
-import_config "*/config.exs"
 import_config "#{Mix.env}.exs"
+import_config "*/config.exs"
+import_config "*/#{Mix.env}.exs"

--- a/config/entity/config.exs
+++ b/config/entity/config.exs
@@ -8,5 +8,3 @@ config :helix, Helix.Entity.Repo,
   password: System.get_env("HELIX_DB_PASS") || "postgres",
   hostname: System.get_env("HELIX_DB_HOST") || "localhost",
   types: HELL.PostgrexTypes
-
-import_config "#{Mix.env}.exs"

--- a/config/hardware/config.exs
+++ b/config/hardware/config.exs
@@ -8,5 +8,3 @@ config :helix, Helix.Hardware.Repo,
   password: System.get_env("HELIX_DB_PASS") || "postgres",
   hostname: System.get_env("HELIX_DB_HOST") || "localhost",
   types: HELL.PostgrexTypes
-
-import_config "#{Mix.env}.exs"

--- a/config/log/config.exs
+++ b/config/log/config.exs
@@ -8,5 +8,3 @@ config :helix, Helix.Log.Repo,
   password: System.get_env("HELIX_DB_PASS") || "postgres",
   hostname: System.get_env("HELIX_DB_HOST") || "localhost",
   types: HELL.PostgrexTypes
-
-import_config "#{Mix.env}.exs"

--- a/config/npc/config.exs
+++ b/config/npc/config.exs
@@ -8,5 +8,3 @@ config :helix, Helix.NPC.Repo,
   password: System.get_env("HELIX_DB_PASS") || "postgres",
   hostname: System.get_env("HELIX_DB_HOST") || "localhost",
   types: HELL.PostgrexTypes
-
-import_config "#{Mix.env}.exs"

--- a/config/process/config.exs
+++ b/config/process/config.exs
@@ -8,5 +8,3 @@ config :helix, Helix.Process.Repo,
   password: System.get_env("HELIX_DB_PASS") || "postgres",
   hostname: System.get_env("HELIX_DB_HOST") || "localhost",
   types: HELL.PostgrexTypes
-
-import_config "#{Mix.env}.exs"

--- a/config/server/config.exs
+++ b/config/server/config.exs
@@ -8,5 +8,3 @@ config :helix, Helix.Server.Repo,
   password: System.get_env("HELIX_DB_PASS") || "postgres",
   hostname: System.get_env("HELIX_DB_HOST") || "localhost",
   types: HELL.PostgrexTypes
-
-import_config "#{Mix.env}.exs"

--- a/config/software/config.exs
+++ b/config/software/config.exs
@@ -8,5 +8,3 @@ config :helix, Helix.Software.Repo,
   password: System.get_env("HELIX_DB_PASS") || "postgres",
   hostname: System.get_env("HELIX_DB_HOST") || "localhost",
   types: HELL.PostgrexTypes
-
-import_config "#{Mix.env}.exs"

--- a/graphs.sh
+++ b/graphs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p graphs
+
+mix xref graph \
+    --format dot \
+    --exclude lib/hell/postgrex_types.ex \
+    --exclude lib/hell/hell/constant.ex \
+    --exclude lib/hell/hell/directory.ex \
+    --exclude lib/hell/hell/ip \
+    --exclude lib/hell/hell/ltree.ex \
+    --exclude lib/hell/hell/mac_addr.ex \
+    --exclude lib/hell/hell/macro_helpers.ex \
+    --exclude lib/hell/hell/pk.ex \
+    --exclude lib/hell/hell/pk/header.ex \
+    --exclude lib/hell/mix/tasks/seeds.ex \
+    --exclude lib/hell/mix/tasks/test.ex  \
+    --exclude lib/release.ex \
+    --exclude lib/event.ex \
+    --exclude lib/event_dispatcher.ex >> /dev/null
+dot -Tpng xref_graph.dot -o graphs/overview.png
+
+mix xref graph --format dot --source lib/event_dispatcher.ex >> /dev/null
+dot -Tpng xref_graph.dot -o graphs/event_consumers.png
+
+mix xref graph --format dot --exclude lib/event_dispatcher.ex --sink lib/event.ex >> /dev/null
+dot -Tpng xref_graph.dot -o graphs/event_publishers.png
+
+mix xref graph --format dot
+mv xref_graph.dot graphs/xref_graph.dot
+
+echo """
+Output Graphs can be found on graphs/ folder
+"""

--- a/lib/account/model/account.ex
+++ b/lib/account/model/account.ex
@@ -40,7 +40,7 @@ defmodule Helix.Account.Model.Account do
 
   @derive {Poison.Encoder, only: [:email, :username, :account_id]}
   @primary_key false
-  @ecto_autogenerate {:account_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:account_id, {PK, :pk_for, [:account_account]}}
   schema "accounts" do
     field :account_id, HELL.PK,
       primary_key: true

--- a/lib/event.ex
+++ b/lib/event.ex
@@ -1,17 +1,10 @@
 defmodule Helix.Event do
 
-  use HELF.Event
-
-  alias Helix.Software
+  alias Helix.Event.Dispatcher
 
   # TODO: This type belongs to HELF.Event
   @type t :: struct
 
-  event Software.Model.SoftwareType.Encryptor.ProcessConclusionEvent,
-    Software.Service.Event.Encryptor,
-    :complete
-
-  event Software.Model.SoftwareType.Decryptor.ProcessConclusionEvent,
-    Software.Service.Event.Decryptor,
-    :complete
+  def emit(event),
+    do: Dispatcher.emit(event)
 end

--- a/lib/event_dispatcher.ex
+++ b/lib/event_dispatcher.ex
@@ -1,0 +1,15 @@
+defmodule Helix.Event.Dispatcher do
+  @moduledoc false
+
+  use HELF.Event
+
+  alias Helix.Software
+
+  event Software.Model.SoftwareType.Encryptor.ProcessConclusionEvent,
+    Software.Service.Event.Encryptor,
+    :complete
+
+  event Software.Model.SoftwareType.Decryptor.ProcessConclusionEvent,
+    Software.Service.Event.Decryptor,
+    :complete
+end

--- a/lib/hardware/model/component/cpu.ex
+++ b/lib/hardware/model/component/cpu.ex
@@ -31,7 +31,7 @@ defmodule Helix.Hardware.Model.Component.CPU do
 
   @spec create_from_spec(ComponentSpec.t) :: Ecto.Changeset.t
   def create_from_spec(cs = %ComponentSpec{spec: spec}) do
-    cpu_id = PK.pk_for(__MODULE__)
+    cpu_id = PK.pk_for(:hardware_component_cpu)
     params = Map.take(spec, ["clock", "cores"])
 
     component = Component.create_from_spec(cs, cpu_id)

--- a/lib/hardware/model/component/hdd.ex
+++ b/lib/hardware/model/component/hdd.ex
@@ -29,7 +29,7 @@ defmodule Helix.Hardware.Model.Component.HDD do
 
   @spec create_from_spec(ComponentSpec.t) :: Ecto.Changeset.t
   def create_from_spec(cs = %ComponentSpec{spec: spec}) do
-    hdd_id = PK.pk_for(__MODULE__)
+    hdd_id = PK.pk_for(:hardware_component_hdd)
     params = Map.take(spec, ["hdd_size"])
     component = Component.create_from_spec(cs, hdd_id)
 

--- a/lib/hardware/model/component/nic.ex
+++ b/lib/hardware/model/component/nic.ex
@@ -37,7 +37,7 @@ defmodule Helix.Hardware.Model.Component.NIC do
 
   @spec create_from_spec(ComponentSpec.t) :: Ecto.Changeset.t
   def create_from_spec(cs = %ComponentSpec{spec: _}) do
-    nic_id = PK.pk_for(__MODULE__)
+    nic_id = PK.pk_for(:hardware_component_nic)
     component = Component.create_from_spec(cs, nic_id)
 
     %__MODULE__{}

--- a/lib/hardware/model/component/ram.ex
+++ b/lib/hardware/model/component/ram.ex
@@ -31,7 +31,7 @@ defmodule Helix.Hardware.Model.Component.RAM do
   @spec create_from_spec(ComponentSpec.t) :: Ecto.Changeset.t
   def create_from_spec(cs = %ComponentSpec{spec: spec}) do
     params = Map.take(spec, ["ram_size"])
-    ram_id = PK.pk_for(__MODULE__)
+    ram_id = PK.pk_for(:hardware_component_ram)
     component = Component.create_from_spec(cs, ram_id)
 
     %__MODULE__{}

--- a/lib/hardware/model/motherboard.ex
+++ b/lib/hardware/model/motherboard.ex
@@ -43,7 +43,7 @@ defmodule Helix.Hardware.Model.Motherboard do
   end
 
   def create_from_spec(cs = %ComponentSpec{spec: %{"slots" => slots}}) do
-    motherboard_id = PK.pk_for(__MODULE__)
+    motherboard_id = PK.pk_for(:hardware_motherboard)
 
     slots = Enum.map(slots, fn {id, spec} ->
       component_type =

--- a/lib/hardware/model/motherboard_slot.ex
+++ b/lib/hardware/model/motherboard_slot.ex
@@ -35,7 +35,7 @@ defmodule Helix.Hardware.Model.MotherboardSlot do
   @required_fields ~w/motherboard_id link_component_type slot_internal_id/a
 
   @primary_key false
-  @ecto_autogenerate {:slot_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:slot_id, {PK, :pk_for, [:hardware_motherboard_slot]}}
   schema "motherboard_slots" do
     field :slot_id, PK,
       primary_key: true

--- a/lib/hardware/model/network_connection.ex
+++ b/lib/hardware/model/network_connection.ex
@@ -19,7 +19,7 @@ defmodule Helix.Hardware.Model.NetworkConnection do
   @one_ip_per_network_index :network_connections_network_id_ip_unique_index
 
   @primary_key false
-  @ecto_autogenerate {:network_conection_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:network_conection_id, {PK, :pk_for, [:hardware_network_connection]}}
   schema "network_connections" do
     field :network_connection_id, PK,
       primary_key: true

--- a/lib/hardware/model/network_connection.ex
+++ b/lib/hardware/model/network_connection.ex
@@ -19,7 +19,10 @@ defmodule Helix.Hardware.Model.NetworkConnection do
   @one_ip_per_network_index :network_connections_network_id_ip_unique_index
 
   @primary_key false
-  @ecto_autogenerate {:network_conection_id, {PK, :pk_for, [:hardware_network_connection]}}
+  @ecto_autogenerate {
+    :network_conection_id,
+    {PK, :pk_for, [:hardware_network_connection]}
+  }
   schema "network_connections" do
     field :network_connection_id, PK,
       primary_key: true

--- a/lib/hell/hell/pk/header.ex
+++ b/lib/hell/hell/pk/header.ex
@@ -4,42 +4,42 @@ defmodule HELL.PK.Header do
     # Network
     # Note that network is the one to receive the 0:0:0 pk head so we can use
     # "::" as a constant value for the internet (ie: global all-players network)
-    Helix.Network.Model.Network                     => [0x0000, 0x0000, 0x0000],
-
-    # Account
-    Helix.Account.Model.Account                     => [0x0001, 0x0000, 0x0000],
-
-    # NPC
-    Helix.NPC.Model.NPC                             => [0x0002, 0x0000, 0x0000],
-
-    # Clan
-    Helix.Clan.Model.Clan                           => [0x0003, 0x0000, 0x0000],
-
-    # Server
-    Helix.Server.Model.Server                       => [0x0010, 0x0000, 0x0000],
-
-    # Hardware
-    Helix.Hardware.Model.Component                  => [0xffff], # FIXME
-    Helix.Hardware.Model.Motherboard                => [0x0011, 0x0001, 0x0000],
-    Helix.Hardware.Model.Component.HDD              => [0x0011, 0x0001, 0x0001],
-    Helix.Hardware.Model.Component.CPU              => [0x0011, 0x0001, 0x0002],
-    Helix.Hardware.Model.Component.RAM              => [0x0011, 0x0001, 0x0003],
-    Helix.Hardware.Model.Component.NIC              => [0x0011, 0x0001, 0x0004],
-    Helix.Hardware.Model.MotherboardSlot            => [0x0011, 0x0002, 0x0000],
-    Helix.Hardware.Model.NetworkConnection          => [0x0011, 0x0003, 0x0000],
-
-    # Sofware
-    Helix.Software.Model.File                       => [0x0020, 0x0000, 0x0000],
-    Helix.Software.Model.Storage                    => [0x0020, 0x0001, 0x0000],
-    Helix.Software.Model.StorageDrive               => [0x0020, 0x0001, 0x0001],
-    Helix.Software.Model.ModuleRole                 => [0x0020, 0x0002, 0x0000],
-
-    # Process
-    Helix.Process.Model.Process                     => [0x0021, 0x0000, 0x0000],
-
-    # Log
-    Helix.Log.Model.Log                             => [0x0030, 0x0000, 0x0000],
-    Helix.Log.Model.Revision                        => [0x0030, 0x0001, 0x0000]
+    network_network:
+      [0x0000, 0x0000, 0x0000],
+    account_account:
+      [0x0001, 0x0000, 0x0000],
+    npc_npc:
+      [0x0002, 0x0000, 0x0000],
+    clan_clan:
+      [0x0003, 0x0000, 0x0000],
+    server_server:
+      [0x0010, 0x0000, 0x0000],
+    hardware_component:
+      [0xffff], # FIXME
+    hardware_motherboard:
+      [0x0011, 0x0001, 0x0001],
+    hardware_component_hdd:
+      [0x0011, 0x0001, 0x0002],
+    hardware_component_cpu:
+      [0x0011, 0x0001, 0x0003],
+    hardware_component_ram:
+      [0x0011, 0x0001, 0x0004],
+    hardware_component_nic:
+      [0x0011, 0x0001, 0x0005],
+    hardware_motherboard_slot:
+      [0x0011, 0x0002, 0x0000],
+    hardware_network_connection:
+      [0x0011, 0x0003, 0x0000],
+    software_file:
+      [0x0020, 0x0000, 0x0000],
+    software_storage:
+      [0x0020, 0x0001, 0x0000],
+    process_process:
+      [0x0021, 0x0000, 0x0000],
+    log_log:
+      [0x0030, 0x0000, 0x0000],
+    log_revision:
+      [0x0030, 0x0001, 0x0000]
   }
 
   @spec pk_for(module) :: HELL.PK.t

--- a/lib/log/model/log.ex
+++ b/lib/log/model/log.ex
@@ -37,7 +37,7 @@ defmodule Helix.Log.Model.Log do
   @required_fields ~w/server_id entity_id message/a
 
   @primary_key false
-  @ecto_autogenerate {:log_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:log_id, {PK, :pk_for, [:log_log]}}
   schema "logs" do
     field :log_id, PK,
       primary_key: true

--- a/lib/log/model/revision.ex
+++ b/lib/log/model/revision.ex
@@ -27,7 +27,7 @@ defmodule Helix.Log.Model.Revision do
   @creation_fields ~w/entity_id message forge_version log_id/a
 
   @primary_key false
-  @ecto_autogenerate {:revision_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:revision_id, {PK, :pk_for, [:log_revision]}}
   schema "revisions" do
     field :revision_id, PK,
       primary_key: true

--- a/lib/npc/model/npc.ex
+++ b/lib/npc/model/npc.ex
@@ -15,7 +15,7 @@ defmodule Helix.NPC.Model.NPC do
   @creation_fields ~w//a
 
   @primary_key false
-  @ecto_autogenerate {:npc_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:npc_id, {PK, :pk_for, [:npc_npc]}}
   schema "npcs" do
     field :npc_id, HELL.PK,
       primary_key: true

--- a/lib/process/model/process.ex
+++ b/lib/process/model/process.ex
@@ -39,7 +39,7 @@ defmodule Helix.Process.Model.Process do
   @opaque id :: PK.t
 
   @primary_key false
-  @ecto_autogenerate {:process_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:process_id, {PK, :pk_for, [:process_process]}}
   schema "processes" do
     field :process_id, PK,
       primary_key: true

--- a/lib/process/model/process/process_type.ex
+++ b/lib/process/model/process/process_type.ex
@@ -7,7 +7,7 @@ defprotocol Helix.Process.Model.Process.ProcessType do
   @spec dynamic_resources(t) :: [resource]
   def dynamic_resources(data)
 
-  @spec event(t, Process.t, :created | :completed) :: [Helix.Event.t]
+  @spec event(t, Process.t, :created | :completed) :: [struct]
   def event(data, process, circumstance)
 end
 

--- a/lib/server/model/server.ex
+++ b/lib/server/model/server.ex
@@ -31,7 +31,7 @@ defmodule Helix.Server.Model.Server do
   @update_fields ~w/poi_id/a
 
   @primary_key false
-  @ecto_autogenerate {:server_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:server_id, {PK, :pk_for, [:server_server]}}
   schema "servers" do
     field :server_id, HELL.PK,
       primary_key: true

--- a/lib/software/model/file.ex
+++ b/lib/software/model/file.ex
@@ -51,7 +51,7 @@ defmodule Helix.Software.Model.File do
   @software_types Map.keys(SoftwareType.possible_types())
 
   @primary_key false
-  @ecto_autogenerate {:file_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:file_id, {PK, :pk_for, [:software_file]}}
   schema "files" do
     field :file_id, HELL.PK,
       primary_key: true

--- a/lib/software/model/storage.ex
+++ b/lib/software/model/storage.ex
@@ -15,7 +15,7 @@ defmodule Helix.Software.Model.Storage do
   }
 
   @primary_key false
-  @ecto_autogenerate {:storage_id, {PK, :pk_for, [__MODULE__]}}
+  @ecto_autogenerate {:storage_id, {PK, :pk_for, [:software_storage]}}
   schema "storages" do
     field :storage_id, HELL.PK,
       primary_key: true

--- a/test/entity/controller/entity_test.exs
+++ b/test/entity/controller/entity_test.exs
@@ -2,13 +2,10 @@ defmodule Helix.Entity.Controller.EntityTest do
 
   use ExUnit.Case, async: true
 
-  alias HELL.PK
   alias HELL.TestHelper.Random
   alias Helix.Entity.Controller.Entity, as: EntityController
   alias Helix.Entity.Model.Entity
   alias Helix.Entity.Repo
-  alias Helix.Server.Model.Server
-  alias Helix.Hardware.Model.Component
 
   alias Helix.Entity.Factory
 
@@ -91,13 +88,13 @@ defmodule Helix.Entity.Controller.EntityTest do
   describe "link_component/2" do
     test "succeeds with entity struct" do
       entity = Factory.insert(:entity)
-      component_id = PK.pk_for(Component)
+      component_id = Random.pk()
 
       assert {:ok, _} = EntityController.link_component(entity, component_id)
     end
 
     test "fails when entity doesn't exist" do
-      component_id = PK.pk_for(Component)
+      component_id = Random.pk()
 
       result = EntityController.link_component(%Entity{}, component_id)
       assert {:error, _} = result
@@ -128,13 +125,13 @@ defmodule Helix.Entity.Controller.EntityTest do
   describe "link_server/2" do
     test "succeeds with entity struct" do
       entity = Factory.insert(:entity)
-      server_id = PK.pk_for(Server)
+      server_id = Random.pk()
 
       assert {:ok, _} = EntityController.link_server(entity, server_id)
     end
 
     test "fails when entity doesn't exist" do
-      server_id = PK.pk_for(Server)
+      server_id = Random.pk()
 
       result = EntityController.link_server(%Entity{}, server_id)
       assert {:error, _} = result

--- a/test/npc/controller/npc_test.exs
+++ b/test/npc/controller/npc_test.exs
@@ -2,9 +2,9 @@ defmodule Helix.NPC.Controller.NPCTest do
 
   use ExUnit.Case, async: true
 
-  alias HELL.PK
+  alias HELL.TestHelper.Random
   alias Helix.NPC.Controller.NPC, as: NPCController
-  alias Helix.NPC.Model.NPC, as: NPC
+  alias Helix.NPC.Model.NPC
 
   @moduletag :integration
 
@@ -21,7 +21,7 @@ defmodule Helix.NPC.Controller.NPCTest do
     end
 
     test "fails when npc with id doesn't exist" do
-      bogus = PK.pk_for(NPC)
+      bogus = Random.pk()
       refute NPCController.fetch(bogus)
     end
   end

--- a/test/software/controller/file_text_test.exs
+++ b/test/software/controller/file_text_test.exs
@@ -2,9 +2,8 @@ defmodule Helix.Software.Controller.FileTextTest do
 
   use ExUnit.Case, async: true
 
-  alias HELL.PK
+  alias HELL.TestHelper.Random
   alias Helix.Software.Controller.FileText, as: FileTextController
-  alias Helix.Software.Model.File
   alias Helix.Software.Model.FileText
 
   alias Helix.Software.Factory
@@ -40,7 +39,7 @@ defmodule Helix.Software.Controller.FileTextTest do
     end
 
     test "returns nil if file_text with id doesn't exists" do
-      bogus = Factory.build(:file, %{file_id: PK.pk_for(File)})
+      bogus = Factory.build(:file, %{file_id: Random.pk()})
       refute FileTextController.fetch(bogus)
     end
   end

--- a/test/software/controller/storage_drive_test.exs
+++ b/test/software/controller/storage_drive_test.exs
@@ -2,8 +2,7 @@ defmodule Helix.Software.Controller.StorageDriveTest do
 
   use ExUnit.Case, async: true
 
-  alias HELL.PK
-  alias Helix.Hardware.Model.Component
+  alias HELL.TestHelper.Random
   alias Helix.Software.Controller.StorageDrive, as: Controller
 
   alias Helix.Software.Factory
@@ -11,7 +10,7 @@ defmodule Helix.Software.Controller.StorageDriveTest do
   @moduletag :integration
 
   test "linking succeeds with a valid storage" do
-    drive_id = PK.pk_for(Component)
+    drive_id = Random.pk()
     storage = Factory.insert(:storage, %{drives: []})
 
     Controller.link_drive(storage, drive_id)

--- a/test/software/controller/storage_test.exs
+++ b/test/software/controller/storage_test.exs
@@ -2,7 +2,7 @@ defmodule Helix.Software.Controller.StorageTest do
 
   use ExUnit.Case, async: true
 
-  alias HELL.PK
+  alias HELL.TestHelper.Random
   alias Helix.Software.Controller.Storage, as: StorageController
   alias Helix.Software.Model.Storage
 
@@ -22,7 +22,7 @@ defmodule Helix.Software.Controller.StorageTest do
     end
 
     test "returns nil if storage with id doesn't exists" do
-      storage_id = PK.pk_for(Storage)
+      storage_id = Random.pk()
       refute StorageController.fetch(storage_id)
     end
   end

--- a/test/software/model/file_text_test.exs
+++ b/test/software/model/file_text_test.exs
@@ -2,9 +2,8 @@ defmodule Helix.Software.Model.FileTextTest do
 
   use ExUnit.Case, async: true
 
-  alias HELL.PK
   alias Ecto.Changeset
-  alias Helix.Software.Model.File
+  alias HELL.TestHelper.Random
   alias Helix.Software.Model.FileText
 
   alias Helix.Software.Factory
@@ -14,7 +13,7 @@ defmodule Helix.Software.Model.FileTextTest do
   defp generate_params do
     :file_text
     |> Factory.params_for()
-    |> Map.put(:file_id, PK.pk_for(File))
+    |> Map.put(:file_id, Random.pk())
     |> Map.drop([:inserted_at, :updated_at])
   end
 

--- a/test/support/software_factory.ex
+++ b/test/support/software_factory.ex
@@ -2,9 +2,7 @@ defmodule Helix.Software.Factory do
 
   use ExMachina.Ecto, repo: Helix.Software.Repo
 
-  alias HELL.PK
   alias HELL.TestHelper.Random
-  alias Helix.Hardware.Model.Component
   alias Helix.Software.Model.StorageDrive
   alias Helix.Software.Model.SoftwareType
 
@@ -64,5 +62,5 @@ defmodule Helix.Software.Factory do
   end
 
   defp prepare(:storage_drive),
-    do: %StorageDrive{drive_id: PK.pk_for(Component)}
+    do: %StorageDrive{drive_id: Random.pk()}
 end


### PR DESCRIPTION
Note about last commit:

`HELF.Event` will always depend on compile-time on the event struct module and on the event handler. But the way things are organized, if an event is recompiled, only the dispatcher has to be recompiled. Eg:
```
_build/dev/lib/helix/ebin/ MODIFY Elixir.Helix.Software.Service.Event.Decryptor.beam
_build/dev/lib/helix/ebin/ MODIFY Elixir.Helix.Event.Dispatcher.beam
```
So i am okay with it

About PK, since it defined lot of module atoms, elixir made it depend on the models (and in exchange all models that used autogenerated pks had compile-time dependency on pk), so, whenever you changed a model that used autogenerated pks, you would recompile that model, the controllers/services/etc that depended on that model, the pk module, all models that used autogenerated pks and every controllers/services/etc that depended on those models. By not having implicit potential dependency on the models (by using generic atoms), this issue was solved and now when you modify a model that uses pk, you will probably only have to recompile a few modules (instead of ~50).

I also added an util to generate dependency graphs. It's very useful to see the overview of system dependency, the event-related dependency graph etc. It also generates a .dot file and store it. I did it this way because i hope that, in the future, our jenkins pipeline could compare this generated dot file with master's generated dot file, that way we can give a second look before accepting reviews as it simply overviews what was introduced through a dependency graph (i believe it could help us to avoid potential bugs)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/124)
<!-- Reviewable:end -->
