### PR TITLE
Update `get_files_on_target_storage/2` to return encrypted files

### DIFF
--- a/lib/software/controller/file.ex
+++ b/lib/software/controller/file.ex
@@ -1,6 +1,5 @@
 defmodule Helix.Software.Controller.File do
 
-  alias Helix.Software.Controller.CryptoKey
   alias Helix.Software.Model.File
   alias Helix.Software.Model.FileModule
   alias Helix.Software.Model.Storage
@@ -22,20 +21,13 @@ defmodule Helix.Software.Controller.File do
   def fetch(file_id),
     do: Repo.get(File, file_id)
 
-  @spec get_files_on_target_storage(Storage.t, Storage.t) :: [File.t]
+  @spec get_files_on_target_storage(Storage.t) :: [File.t]
   @doc """
-  Gets all files on `target_storage` that are not encrypted or for whom is there
-  a key on `origin_storage`
+  Gets all files on `target_storage`
   """
-  def get_files_on_target_storage(origin_storage, target_storage) do
-    keyed_files = CryptoKey.get_files_targeted_on_storage(
-      origin_storage,
-      target_storage)
-
+  def get_files_on_target_storage(target_storage) do
     target_storage
     |> File.Query.from_storage()
-    |> File.Query.not_encrypted()
-    |> File.Query.from_id_list(keyed_files, :or)
     |> Repo.all()
   end
 


### PR DESCRIPTION
This change removed `origin_storage` from that function as there's no need to check the keys anymore, this also introduced a function that returns every file `decryptable` file (based on `origin_storage`).

It looks that `decryptable` is not a valid english word, I don't like the `get_decryptable_files_on_target_storage/2` name, so I'm open to suggestions.

Well, maybe the name's okay, so I'm keeping this open for revision, I'll remove the fixme if it's alright.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/142)
<!-- Reviewable:end -->
