### PR TITLE
Ecto sandbox

### DIFF
--- a/test/account/controller/account_test.exs
+++ b/test/account/controller/account_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Account.Controller.AccountTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias Comeonin.Bcrypt
   alias HELL.TestHelper.Random
@@ -11,8 +11,6 @@ defmodule Helix.Account.Controller.AccountTest do
   alias Helix.Account.Repo
 
   alias Helix.Account.Factory
-
-  @moduletag :integration
 
   defp params do
     %{

--- a/test/account/controller/session_test.exs
+++ b/test/account/controller/session_test.exs
@@ -1,14 +1,12 @@
 defmodule Helix.Account.Controller.SessionTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias Helix.Account.Controller.Session
   alias Helix.Account.Model.AccountSession
   alias Helix.Account.Repo
 
   alias Helix.Account.Factory
-
-  @moduletag :integration
 
   describe "generate_token/1" do
     test "succeeds with valid account" do

--- a/test/account/http/controller/account_test.exs
+++ b/test/account/http/controller/account_test.exs
@@ -1,7 +1,9 @@
 defmodule Helix.Account.HTTP.Controller.AccountTest do
 
   use Helix.Test.ConnCase
+  use Helix.Test.IntegrationCase
 
+  alias HELL.TestHelper.Random
   alias Helix.Account.Service.API.Session
 
   alias Helix.Account.Factory
@@ -10,7 +12,7 @@ defmodule Helix.Account.HTTP.Controller.AccountTest do
     test "creates account when input is valid", context do
       password = Burette.Internet.password()
       params = %{
-        "username" => Burette.Internet.username(),
+        "username" => Random.username(),
         "email" => Burette.Internet.email(),
         "password" => password
       }

--- a/test/account/service/api/account_test.exs
+++ b/test/account/service/api/account_test.exs
@@ -1,9 +1,8 @@
 defmodule Helix.Account.Service.API.AccountTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias Helix.Account.Model.Account
-  alias Helix.Account.Repo
   alias Helix.Account.Service.API.Account, as: API
 
   alias Helix.Account.Factory
@@ -16,8 +15,7 @@ defmodule Helix.Account.Service.API.AccountTest do
         password: "Would you very kindly let me in, please, good sir"
       }
 
-      assert {:ok, acc = %Account{}} = API.create(params)
-      Repo.delete!(acc) # FIXME: Ecto.Sandbox || on_exit
+      assert {:ok, %Account{}} = API.create(params)
     end
 
     test "returns changeset when input is invalid" do
@@ -36,8 +34,7 @@ defmodule Helix.Account.Service.API.AccountTest do
       username = "good_username1"
       password = "Would you very kindly let me in, please, good sir"
 
-      assert {:ok, acc = %Account{}} = API.create(email, username, password)
-      Repo.delete!(acc) # FIXME: Ecto.Sandbox || on_exit
+      assert {:ok, %Account{}} = API.create(email, username, password)
     end
 
     test "returns changeset when input is invalid" do

--- a/test/account/websocket/channel/account_test.exs
+++ b/test/account/websocket/channel/account_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Account.Websocket.Channel.AccountTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias Helix.Websocket.Socket
   alias Helix.Account.Service.API.Session

--- a/test/account/websocket/routes_test.exs
+++ b/test/account/websocket/routes_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Account.Websocket.RoutesTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias Helix.Websocket.Socket
   alias Helix.Account.Service.API.Session

--- a/test/entity/controller/entity_test.exs
+++ b/test/entity/controller/entity_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Entity.Controller.EntityTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Entity.Controller.Entity, as: EntityController
@@ -17,8 +17,6 @@ defmodule Helix.Entity.Controller.EntityTest do
       entity_type: e.entity_type
     }
   end
-
-  @moduletag :integration
 
   describe "entity creation" do
     test "succeeds with valid params" do

--- a/test/hardware/controller/component_spec_test.exs
+++ b/test/hardware/controller/component_spec_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Hardware.Controller.ComponentSpecTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Hardware.Controller.ComponentSpec, as: ComponentSpecController
@@ -9,8 +9,6 @@ defmodule Helix.Hardware.Controller.ComponentSpecTest do
   alias Helix.Hardware.Repo
 
   alias Helix.Hardware.Factory
-
-  @moduletag :integration
 
   describe "fetching" do
     test "succeeds by id" do

--- a/test/hardware/controller/component_test.exs
+++ b/test/hardware/controller/component_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Hardware.Controller.ComponentTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Hardware.Controller.Component, as: ComponentController
@@ -8,8 +8,6 @@ defmodule Helix.Hardware.Controller.ComponentTest do
   alias Helix.Hardware.Repo
 
   alias Helix.Hardware.Factory
-
-  @moduletag :integration
 
   describe "fetching" do
     test "succeeds by id" do

--- a/test/hardware/controller/motherboard_test.exs
+++ b/test/hardware/controller/motherboard_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Hardware.Controller.MotherboardTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias Helix.Hardware.Controller.Motherboard, as: MotherboardController
   alias Helix.Hardware.Model.ComponentType
@@ -9,8 +9,6 @@ defmodule Helix.Hardware.Controller.MotherboardTest do
   alias Helix.Hardware.Repo
 
   alias Helix.Hardware.Factory
-
-  @moduletag :integration
 
   defp component_of_type(type) do
     specialized_component = Factory.insert(type)

--- a/test/hardware/service/api/component_spec_test.exs
+++ b/test/hardware/service/api/component_spec_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Hardware.Service.API.ComponentSpecTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Hardware.Service.API.ComponentSpec, as: API
@@ -8,8 +8,6 @@ defmodule Helix.Hardware.Service.API.ComponentSpecTest do
   alias Helix.Hardware.Repo
 
   alias Helix.Hardware.Factory
-
-  @moduletag :integration
 
   describe "create/1" do
     test "succeeds with valid input" do

--- a/test/hardware/service/api/component_test.exs
+++ b/test/hardware/service/api/component_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Hardware.Service.API.ComponentTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Hardware.Service.API.Component, as: API
@@ -9,8 +9,6 @@ defmodule Helix.Hardware.Service.API.ComponentTest do
   alias Helix.Hardware.Repo
 
   alias Helix.Hardware.Factory
-
-  @moduletag :integration
 
   describe "create_from_spec/1" do
     test "succeeds with valid input" do

--- a/test/hardware/service/api/motherboard_test.exs
+++ b/test/hardware/service/api/motherboard_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Hardware.Service.API.MotherboardTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Hardware.Service.API.Motherboard, as: API
@@ -9,8 +9,6 @@ defmodule Helix.Hardware.Service.API.MotherboardTest do
   alias Helix.Hardware.Repo
 
   alias Helix.Hardware.Factory
-
-  @moduletag :integration
 
   describe "fetch!/1" do
     test "succeeds by component" do

--- a/test/log/controller/log_test.exs
+++ b/test/log/controller/log_test.exs
@@ -1,13 +1,11 @@
 defmodule Helix.Log.Controller.LogTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Log.Controller.Log, as: Controller
   alias Helix.Log.Repo
   alias Helix.Log.Model.Log
-
-  @moduletag :integration
 
   # FIXME: this is bad, create a factory and remove this
   defp create_log(params \\ []) do

--- a/test/network/controller/tunnel_test.exs
+++ b/test/network/controller/tunnel_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Network.Controller.TunnelTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Network.Controller.Tunnel, as: Controller
@@ -9,8 +9,6 @@ defmodule Helix.Network.Controller.TunnelTest do
   alias Helix.Network.Repo
 
   alias Helix.Network.Factory
-
-  @moduletag :integration
 
   @internet Repo.get!(Network, "::")
 

--- a/test/network/controller/tunnel_test.exs
+++ b/test/network/controller/tunnel_test.exs
@@ -8,6 +8,8 @@ defmodule Helix.Network.Controller.TunnelTest do
   alias Helix.Network.Model.Network
   alias Helix.Network.Repo
 
+  alias Helix.Network.Factory
+
   @moduletag :integration
 
   @internet Repo.get!(Network, "::")
@@ -18,23 +20,19 @@ defmodule Helix.Network.Controller.TunnelTest do
     end
 
     test "returns true if there is any tunnel open linking two nodes" do
-      gateway = Random.pk()
-      destination = Random.pk()
-      bounces = []
-
-      Controller.create(@internet, gateway, destination, bounces)
+      tunnel = Factory.insert(:tunnel, network: @internet)
+      gateway = tunnel.gateway_id
+      destination = tunnel.destination_id
 
       assert Controller.connected?(gateway, destination)
     end
 
     @tag :pending
     test "can be filtered by network" do
-      gateway = Random.pk()
-      destination = Random.pk()
-      bounces = []
-      network = :todo
-
-      Controller.create(network, gateway, destination, bounces)
+      tunnel = Factory.insert(:tunnel, network: :todo)
+      network = tunnel.network
+      gateway = tunnel.gateway_id
+      destination = tunnel.destination_id
 
       refute Controller.connected?(gateway, destination, @internet)
       assert Controller.connected?(gateway, destination, network)
@@ -45,28 +43,22 @@ defmodule Helix.Network.Controller.TunnelTest do
     test "returns all connections that pass through node" do
       server = Random.pk()
 
-      {:ok, tunnel1} = Controller.create(
-        @internet,
-        server,
-        Random.pk(),
-        [])
+      tunnel1 = Factory.insert(:tunnel,
+        network: @internet,
+        gateway_id: server)
 
       Controller.start_connection(tunnel1, "ssh")
 
-      {:ok, tunnel2} = Controller.create(
-        @internet,
-        Random.pk(),
-        server,
-        [])
+      tunnel2 = Factory.insert(:tunnel,
+        network: @internet,
+        destination_id: server)
 
       Controller.start_connection(tunnel2, "ssh")
       Controller.start_connection(tunnel2, "ssh")
 
-      {:ok, tunnel3} = Controller.create(
-        @internet,
-        Random.pk(),
-        Random.pk(),
-        [Random.pk(), server, Random.pk(), Random.pk()])
+      tunnel3 = Factory.insert(:tunnel,
+        network: @internet,
+        bounces: [Random.pk(), server, Random.pk(), Random.pk()])
 
       Controller.start_connection(tunnel3, "ssh")
       Controller.start_connection(tunnel3, "ssh")
@@ -82,31 +74,26 @@ defmodule Helix.Network.Controller.TunnelTest do
     test "list the conections that are incident on node" do
       server = Random.pk()
 
-      {:ok, tunnel1} = Controller.create(
-        @internet,
-        server,
-        Random.pk(),
-        [Random.pk(), Random.pk()])
+      tunnel1 = Factory.insert(:tunnel,
+        network: @internet,
+        gateway_id: server,
+        bounces: [Random.pk(), Random.pk()])
 
       # This is not incident since the connection emanates from the server
       Controller.start_connection(tunnel1, "ssh")
 
-      {:ok, tunnel2} = Controller.create(
-        @internet,
-        Random.pk(),
-        server,
-        [Random.pk(), Random.pk()])
-
+      tunnel2 = Factory.insert(:tunnel,
+        network: @internet,
+        destination_id: server,
+        bounces: [Random.pk(), Random.pk()])
       # Those are incident because they emanate from a gateway node onto the
       # bounce nodes and finally on the server
       Controller.start_connection(tunnel2, "ssh")
       Controller.start_connection(tunnel2, "ssh")
 
-      {:ok, tunnel3} = Controller.create(
-        @internet,
-        Random.pk(),
-        Random.pk(),
-        [Random.pk(), server, Random.pk()])
+      tunnel3 = Factory.insert(:tunnel,
+        network: @internet,
+        bounces: [Random.pk(), server, Random.pk()])
 
       # Those are also incident as they emanate from the gateway, onto the
       # bounces, onto the specified target and onto the destination
@@ -124,31 +111,27 @@ defmodule Helix.Network.Controller.TunnelTest do
     test "list the conections that emanate from node" do
       server = Random.pk()
 
-      {:ok, tunnel1} = Controller.create(
-        @internet,
-        server,
-        Random.pk(),
-        [Random.pk(), Random.pk()])
+      tunnel1 = Factory.insert(:tunnel,
+        network: @internet,
+        gateway_id: server,
+        bounces: [Random.pk(), Random.pk()])
 
       # This emanates from the server since it goes from the server to the
       # bounces and finally to the destination
       Controller.start_connection(tunnel1, "ssh")
 
-      {:ok, tunnel2} = Controller.create(
-        @internet,
-        Random.pk(),
-        server,
-        [Random.pk(), Random.pk()])
+      tunnel2 = Factory.insert(:tunnel,
+        network: @internet,
+        destination_id: server,
+        bounces: [Random.pk(), Random.pk()])
 
       # Those don't emanate from the server as the connection is incident on it
       Controller.start_connection(tunnel2, "ssh")
       Controller.start_connection(tunnel2, "ssh")
 
-      {:ok, tunnel3} = Controller.create(
-        @internet,
-        Random.pk(),
-        Random.pk(),
-        [Random.pk(), server, Random.pk()])
+      tunnel3 = Factory.insert(:tunnel,
+        network: @internet,
+        bounces: [Random.pk(), server, Random.pk()])
 
       # Those do emanate from server onto another bounce and finally on the
       # destination
@@ -164,15 +147,7 @@ defmodule Helix.Network.Controller.TunnelTest do
 
   describe "start_connection/2" do
     test "starts a new connection every call" do
-      gateway = Random.pk()
-      destination = Random.pk()
-      bounces = []
-
-      {:ok, tunnel} = Controller.create(
-        @internet,
-        gateway,
-        destination,
-        bounces)
+      tunnel = Factory.insert(:tunnel, network: @internet)
 
       {:ok, connection1, _events} = Controller.start_connection(tunnel, "ssh")
       {:ok, connection2, _events} = Controller.start_connection(tunnel, "ssh")
@@ -188,15 +163,7 @@ defmodule Helix.Network.Controller.TunnelTest do
 
   describe "close_connection/2" do
     test "deletes the connection" do
-      gateway = Random.pk()
-      destination = Random.pk()
-      bounces = []
-
-      {:ok, tunnel} = Controller.create(
-        @internet,
-        gateway,
-        destination,
-        bounces)
+      tunnel = Factory.insert(:tunnel, network: @internet)
 
       {:ok, connection, _events} = Controller.start_connection(tunnel, "ssh")
 

--- a/test/network/service/api/tunnel_test.exs
+++ b/test/network/service/api/tunnel_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Network.Service.TunnelTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   # TODO: Write tests (depends on factory)
 end

--- a/test/network/service/event/tunnel_test.exs
+++ b/test/network/service/event/tunnel_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Network.Service.Event.TunnelTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Event
@@ -8,8 +8,6 @@ defmodule Helix.Network.Service.Event.TunnelTest do
   alias Helix.Network.Model.Network
   alias Helix.Network.Model.Tunnel
   alias Helix.Network.Repo
-
-  @moduletag :integration
 
   @internet Repo.get!(Network, "::")
 

--- a/test/network/service/henforcer/network_test.exs
+++ b/test/network/service/henforcer/network_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Network.Service.Henforcer.NetworkTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   # TODO: Write tests (depends on factory)
 

--- a/test/npc/controller/npc_test.exs
+++ b/test/npc/controller/npc_test.exs
@@ -1,12 +1,10 @@
 defmodule Helix.NPC.Controller.NPCTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.NPC.Controller.NPC, as: NPCController
   alias Helix.NPC.Model.NPC
-
-  @moduletag :integration
 
   # FIXME: add factories as soon as this get more fields
 

--- a/test/process/controller/process_test.exs
+++ b/test/process/controller/process_test.exs
@@ -1,5 +1,6 @@
 defmodule Helix.Process.Controller.ProcessTest do
-  use ExUnit.Case
+
+  use Helix.Test.IntegrationCase
 
   alias Helix.Process.Controller.Process, as: ProcessController
   alias Helix.Process.Model.Process, as: ProcessModel
@@ -7,8 +8,6 @@ defmodule Helix.Process.Controller.ProcessTest do
 
   alias HELL.TestHelper.Random
   alias Helix.Process.Factory
-
-  @moduletag :integration
 
   test "creating succeeds with valid params" do
     params = %{

--- a/test/server/controller/server_test.exs
+++ b/test/server/controller/server_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Server.Controller.ServerTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Server.Controller.Server, as: ServerController
@@ -9,8 +9,6 @@ defmodule Helix.Server.Controller.ServerTest do
   alias Helix.Server.Repo
 
   alias Helix.Server.Factory
-
-  @moduletag :integration
 
   # FIXME: add more tests
 

--- a/test/server/service/api/server_test.exs
+++ b/test/server/service/api/server_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Server.Service.API.ServerTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Server.Model.Server

--- a/test/server/service/henforcer/server_test.exs
+++ b/test/server/service/henforcer/server_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Server.Service.Henforcer.ServerTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Server.Controller.Server, as: ServerController

--- a/test/software/controller/crypto_key_test.exs
+++ b/test/software/controller/crypto_key_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Software.Controller.CryptoKeyTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Software.Controller.CryptoKey, as: CryptoKeyController
@@ -8,8 +8,6 @@ defmodule Helix.Software.Controller.CryptoKeyTest do
   alias Helix.Software.Model.CryptoKey.InvalidatedEvent
 
   alias Helix.Software.Factory
-
-  @moduletag :integration
 
   describe "create/3" do
     test "will create a file for the key on storage" do

--- a/test/software/controller/file_test.exs
+++ b/test/software/controller/file_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Software.Controller.FileTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Software.Controller.File, as: FileController
@@ -9,8 +9,6 @@ defmodule Helix.Software.Controller.FileTest do
   alias Helix.Software.Repo
 
   alias Helix.Software.Factory
-
-  @moduletag :integration
 
   def generate_params do
     storage = Factory.insert(:storage)
@@ -177,6 +175,9 @@ defmodule Helix.Software.Controller.FileTest do
       file0 = Factory.insert(:file)
       similarities = Map.take(file0, [:path, :software_type, :storage])
       file1 = Factory.insert(:file, similarities)
+
+      # FIXME: this is thanks to how ExMachina works
+      file1 = Repo.update! File.update_changeset(file1, similarities)
 
       assert {:error, :file_exists} == FileController.rename(file1, file0.name)
     end

--- a/test/software/controller/file_text_test.exs
+++ b/test/software/controller/file_text_test.exs
@@ -1,14 +1,12 @@
 defmodule Helix.Software.Controller.FileTextTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Software.Controller.FileText, as: FileTextController
   alias Helix.Software.Model.FileText
 
   alias Helix.Software.Factory
-
-  @moduletag :integration
 
   defp generate_params do
     %{file_id: file_id} = Factory.insert(:file)

--- a/test/software/controller/storage_drive_test.exs
+++ b/test/software/controller/storage_drive_test.exs
@@ -1,13 +1,11 @@
 defmodule Helix.Software.Controller.StorageDriveTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Software.Controller.StorageDrive, as: Controller
 
   alias Helix.Software.Factory
-
-  @moduletag :integration
 
   test "linking succeeds with a valid storage" do
     drive_id = Random.pk()

--- a/test/software/controller/storage_test.exs
+++ b/test/software/controller/storage_test.exs
@@ -1,14 +1,12 @@
 defmodule Helix.Software.Controller.StorageTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Software.Controller.Storage, as: StorageController
   alias Helix.Software.Model.Storage
 
   alias Helix.Software.Factory
-
-  @moduletag :integration
 
   # REVIEW: Is this is a good test name, it's weird?
   test "creating always succeeds" do

--- a/test/software/service/event/decryptor_test.exs
+++ b/test/software/service/event/decryptor_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Software.Service.Event.DecryptorTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Event
@@ -11,8 +11,6 @@ defmodule Helix.Software.Service.Event.DecryptorTest do
   alias Helix.Software.Repo
 
   alias Helix.Software.Factory
-
-  @moduletag :integration
 
   describe "when decryption is global" do
     test "on conclusion, removes the crypto version of the target file" do

--- a/test/software/service/event/encryptor_test.exs
+++ b/test/software/service/event/encryptor_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Software.Service.Event.EncryptorTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias HELL.TestHelper.Random
   alias Helix.Event
@@ -11,8 +11,6 @@ defmodule Helix.Software.Service.Event.EncryptorTest do
   alias Helix.Software.Repo
 
   alias Helix.Software.Factory
-
-  @moduletag :integration
 
   describe "when process is completed" do
     test "creates a new key file on storage that binds to target_file" do

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -1,0 +1,19 @@
+defmodule Helix.Test.IntegrationCase do
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      @moduletag :integration
+
+      setup do
+        repos = Application.get_env(:helix, :ecto_repos)
+        Enum.each(repos, fn repo ->
+          :ok = Ecto.Adapters.SQL.Sandbox.checkout(repo)
+
+          Ecto.Adapters.SQL.Sandbox.mode(repo, {:shared, self()})
+        end)
+      end
+    end
+  end
+end

--- a/test/support/network_factory.ex
+++ b/test/support/network_factory.ex
@@ -1,0 +1,120 @@
+defmodule Helix.Network.Factory do
+
+  alias HELL.TestHelper.Random
+  alias Helix.Network.Model.Network
+  alias Helix.Network.Model.Tunnel
+  alias Helix.Network.Model.Connection
+
+  alias Helix.Network.Repo
+
+  @type thing :: :network | :tunnel | :connection
+
+  @spec changeset(thing, map | Keyword.t) ::
+    Ecto.Changeset.t
+  def changeset(thing, params \\ %{}) do
+    attrs =
+      thing
+      |> params_for()
+      |> Map.merge(to_map(params))
+
+    fabricate_changeset(thing, attrs)
+  end
+
+  @spec changeset_list(pos_integer, thing, map | Keyword.t) ::
+    [Ecto.Changeset.t, ...]
+  def changeset_list(n, thing, params \\ %{}) when n >= 1 do
+    for _ <- 1..n,
+      do: changeset(thing, params)
+  end
+
+  @spec build(thing, map | Keyword.t) ::
+    Ecto.Schema.t
+  def build(thing, params \\ %{}) do
+    thing
+    |> changeset(params)
+    |> ensure_valid_changeset()
+    |> Ecto.Changeset.apply_changes()
+  end
+
+  @spec build_list(pos_integer, thing, map | Keyword.t) ::
+    [Ecto.Schema.t, ...]
+  def build_list(n, thing, params \\ %{}) when n >= 1 do
+    for _ <- 1..n,
+      do: build(thing, params)
+  end
+
+  @spec insert(thing, map | Keyword.t) ::
+    Ecto.Schema.t
+  def insert(thing, params \\ %{}) do
+    thing
+    |> changeset(params)
+    |> Repo.insert!()
+  end
+
+  @spec insert_list(pos_integer, thing, map | Keyword.t) ::
+    [Ecto.Schema.t, ...]
+  def insert_list(n, thing, params \\ %{}) when n >= 1 do
+    for _ <- 1..n,
+      do: insert(thing, params)
+  end
+
+  @spec params_for(thing) ::
+    map
+  defp params_for(:network) do
+    %{
+      name: Random.username()
+    }
+  end
+
+  defp params_for(:tunnel) do
+    # REVIEW: maybe it's better to use internet as the default network
+    %{
+      network: changeset(:network),
+      gateway_id: Random.pk(),
+      destination_id: Random.pk(),
+      bounces: []
+    }
+  end
+
+  defp params_for(:connection) do
+    # FIXME: update after turning `connection_type` into a constant
+    %{
+      tunnel: build(:tunnel),
+      connection_type: "ssh"
+    }
+  end
+
+  @spec fabricate_changeset(:network, %{name: String.t}) ::
+    Ecto.Changeset.t
+  defp fabricate_changeset(:network, params) do
+    Network
+    |> struct(params)
+    |> Ecto.Changeset.cast(%{}, [])
+  end
+
+  @spec fabricate_changeset(:tunnel, map) ::
+    Ecto.Changeset.t
+  defp fabricate_changeset(:tunnel, params) do
+    Tunnel.create(
+      params.network,
+      params.gateway_id,
+      params.destination_id,
+      params.bounces)
+  end
+
+  @spec fabricate_changeset(:connection, map) ::
+    Ecto.Changeset.t
+  defp fabricate_changeset(:connection, params) do
+    Connection.create(params.tunnel, params.connection_type)
+  end
+
+  defp to_map(x = %{}),
+    do: x
+  defp to_map(x) when is_list(x),
+    do: :maps.from_list(x)
+
+  defp ensure_valid_changeset(cs = %Ecto.Changeset{valid?: true}),
+    do: cs
+  defp ensure_valid_changeset(cs),
+    do: raise "invalid changeset generated on factory: #{inspect cs}"
+end

--- a/test/websocket/socket_test.exs
+++ b/test/websocket/socket_test.exs
@@ -1,6 +1,6 @@
 defmodule Helix.Websocket.SocketTest do
 
-  use ExUnit.Case, async: true
+  use Helix.Test.IntegrationCase
 
   alias Helix.Account.Controller.Session
   alias Helix.Websocket.Socket


### PR DESCRIPTION
Unfortunately we'll lose the `async` of integration tests, but this will guarantee that we'll have a clean database at the end of the run _and_ that we can keep tests running ad infinitum because collisions now are treated as transaction locks and it won't fail, just delay. Finally, this means that we can use fixtures to test valid and invalid inputs without relying to potentially flawed generators.

So, at the cost of the "quick" test taking ~5s more to complete, we removed all transient errors from our test suite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/158)
<!-- Reviewable:end -->
