### PR TITLE
Hot fix for release error during seed

### DIFF
--- a/lib/release.ex
+++ b/lib/release.ex
@@ -34,6 +34,7 @@ defmodule Helix.Release do
   def seeds do
     start_applications()
     start_repos()
+    start_cache()
 
     :helix
     |> Application.app_dir("priv/**/seeds.exs")
@@ -55,6 +56,12 @@ defmodule Helix.Release do
       {:ok, _} = repo.start_link(pool_size: 1)
     end)
   end
+
+  # HACK: Some seed functions use cache implicitly, and as such require it
+  # to be started. That's what we do here. A better fix would be to disable
+  # cache altogether, by adding something like a `SKIP_CACHE` flag.
+  defp start_cache,
+    do: Helix.Cache.State.Supervisor.start_link()
 
   defp execute_on_all_repos(fun) when is_function(fun, 1) do
     :helix

--- a/lib/universe/npc/seed.ex
+++ b/lib/universe/npc/seed.ex
@@ -103,6 +103,11 @@ defmodule Helix.Universe.NPC.Seed do
     end
   end
 
+  # TODO: Remove need for cache clean up by adding the `SKIP_CACHE` flag.
+  # Note that, as long as the seed process takes less than the PurgeQueue
+  # sync_interval, we don't even have to clean the cache, since teardown
+  # would clean the ETS table without giving it time to sync. I'll leave it
+  # here nonetheless.
   def clean_cache(npcs) do
     # Sync cache
     StatePurgeQueue.sync()


### PR DESCRIPTION
The master build is failing, in short, because Seed is (indirectly) using the Cache, which requires a running GenServer for the PurgeQueue.

This hot fix will ensure all Cache-related processes have been started before applying the seed.

The ideal solution is to add a `SKIP_CACHE` flag, or something like that, to the PurgeQueue, which would lead it to completely disable caching. Useful for: 

1) Release scripts, which do not need any sort of caching
2) Tests, which should run on *both* modes[1][2]
3) Debugging, so it's possible to rule out caching issues 

[1] I don't think we should naively rerun the whole test suite, since many tests would never use the Cache service. Instead, maybe adding a @cache tag to the test/module could be a better idea. This way, we know tests with such tag should run twice.
[2] Another optimization is to skip caching during the tests setup, specially integration ones. Doing so removes the need to `sync() + purge() + sync()` when we setup a server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/245)
<!-- Reviewable:end -->
