### PR TITLE
Use HELF Event and Flow synchrnously on test env

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,7 @@
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], []},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, optional: false]}, {:idna, "5.1.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "hebroker": {:git, "https://github.com/HackerExperience/HeBroker.git", "2a653a43b512c6392f55508dfc1be8463a845b31", []},
-  "helf": {:git, "https://github.com/HackerExperience/HELF.git", "438b46ab174754695bf469114bc7f10e87b0d601", []},
+  "helf": {:git, "https://github.com/HackerExperience/HELF.git", "3ab0d9f69c1a25f745a4f352eeb03352b48f55ec", []},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, optional: false]}]},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},

--- a/test/account/action/account_test.exs
+++ b/test/account/action/account_test.exs
@@ -18,8 +18,6 @@ defmodule Helix.Account.Action.AccountTest do
 
       assert {:ok, %Account{}} = AccountAction.create(params)
 
-      # HACK: workaround for the flow event
-      :timer.sleep(250)
       CacheHelper.sync_test()
     end
 
@@ -41,8 +39,6 @@ defmodule Helix.Account.Action.AccountTest do
 
       assert {:ok, %Account{}} = AccountAction.create(email, username, password)
 
-      # HACK: workaround for the flow event
-      :timer.sleep(100)
       CacheHelper.sync_test()
     end
 

--- a/test/account/action/flow/account_test.exs
+++ b/test/account/action/flow/account_test.exs
@@ -14,10 +14,6 @@ defmodule Helix.Account.Action.Flow.AccountTest do
       account = Factory.insert(:account)
 
       result = AccountFlow.setup_account(account)
-      # FIXME: This is to ensure that all callbacks in the flow are executed
-      #   before the test ends (otherwise the callbacks will not have access to
-      #   the repo because Ecto.Sandbox)
-      :timer.sleep(250)
       CacheHelper.sync_test()
 
       assert {:ok, %{entity: entity}} = result

--- a/test/account/http/controller/webhook_test.exs
+++ b/test/account/http/controller/webhook_test.exs
@@ -33,8 +33,6 @@ defmodule Helix.Account.HTTP.Controller.WebhookTest do
       assert String.downcase(input_data["username"]) == account.username
       assert String.downcase(input_data["email"]) == account.email
 
-      # The account setup event was emited, so we better wait
-      :timer.sleep(500)
       CacheHelper.sync_test()
     end
 

--- a/test/account/internal/account_test.exs
+++ b/test/account/internal/account_test.exs
@@ -31,8 +31,6 @@ defmodule Helix.Account.Internal.AccountTest do
 
       assert {:ok, _} = AccountInternal.create(params)
 
-      # HACK: workaround for the flow event (it's pretty heavy)
-      :timer.sleep(250)
       CacheHelper.sync_test()
     end
 

--- a/test/network/event/tunnel_test.exs
+++ b/test/network/event/tunnel_test.exs
@@ -29,9 +29,6 @@ defmodule Helix.Network.Event.TunnelTest do
 
       Event.emit(events)
 
-      # Let's give it enough time to run
-      :timer.sleep(100)
-
       refute Repo.get(Tunnel, tunnel.tunnel_id)
     end
 
@@ -52,9 +49,6 @@ defmodule Helix.Network.Event.TunnelTest do
       events = TunnelInternal.close_connection(connection)
 
       Event.emit(events)
-
-      # Let's give it enough time to run
-      :timer.sleep(100)
 
       assert Repo.get(Tunnel, tunnel.tunnel_id)
     end

--- a/test/process/query/process_test.exs
+++ b/test/process/query/process_test.exs
@@ -18,7 +18,6 @@ defmodule Helix.Process.Query.ProcessTest do
     account = AccountFactory.insert(:account)
     {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-    :timer.sleep(100)
     CacheHelper.sync_test()
 
     server

--- a/test/process/state/top/server_test.exs
+++ b/test/process/state/top/server_test.exs
@@ -30,7 +30,6 @@ defmodule Helix.Process.State.TOP.TOPServerTest do
     account = AccountFactory.insert(:account)
     {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-    :timer.sleep(100)
     CacheHelper.sync_test()
 
     server

--- a/test/server/internal/server_test.exs
+++ b/test/server/internal/server_test.exs
@@ -20,7 +20,6 @@ defmodule Helix.Server.Internal.ServerTest do
     account = AccountFactory.insert(:account)
     {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-    :timer.sleep(100)
     CacheHelper.sync_test()
 
     {:ok, account: account, server: server}

--- a/test/server/websocket/channel/server_test.exs
+++ b/test/server/websocket/channel/server_test.exs
@@ -34,7 +34,6 @@ defmodule Helix.Server.Websocket.Channel.ServerTest do
   defp create_server_for_account(account) do
     {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-    :timer.sleep(100)
     CacheHelper.sync_test()
 
     server
@@ -148,9 +147,6 @@ defmodule Helix.Server.Websocket.Channel.ServerTest do
     }
 
     assert {:ok, _, _} = join(context.socket, topic, join_msg)
-
-    # This might emit an event...
-    :timer.sleep(250)
   end
 
   test "returns files on server", context do
@@ -175,9 +171,6 @@ defmodule Helix.Server.Websocket.Channel.ServerTest do
     assert is_map(file_map)
     assert Enum.all?(Map.keys(file_map), &is_binary/1)
     assert expected_file_ids == file_ids
-
-    # This might emit an event...
-    :timer.sleep(250)
   end
 
   describe "process.index" do
@@ -211,9 +204,6 @@ defmodule Helix.Server.Websocket.Channel.ServerTest do
       logs = Enum.reject(logs, &(&1.message =~ "logged in as root"))
 
       assert [%{message: "baz"}, %{message: "bar"}, %{message: "foo"}] = logs
-
-      # This might emit an event...
-      :timer.sleep(250)
     end
   end
 

--- a/test/software/action/flow/file_test.exs
+++ b/test/software/action/flow/file_test.exs
@@ -29,7 +29,6 @@ defmodule Helix.Software.Action.Flow.FileTest do
 
       {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-      :timer.sleep(250)
       CacheHelper.sync_test()
 
       {:ok, storages} = CacheQuery.from_server_get_storages(server)
@@ -55,7 +54,6 @@ defmodule Helix.Software.Action.Flow.FileTest do
 
       {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-      :timer.sleep(100)
       CacheHelper.sync_test()
 
       {:ok, storages} = CacheQuery.from_server_get_storages(server)
@@ -78,7 +76,6 @@ defmodule Helix.Software.Action.Flow.FileTest do
 
       {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-      :timer.sleep(250)
       CacheHelper.sync_test()
 
       {:ok, storages} = CacheQuery.from_server_get_storages(server)
@@ -114,7 +111,6 @@ defmodule Helix.Software.Action.Flow.FileTest do
 
       {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-      :timer.sleep(250)
       CacheHelper.sync_test()
 
       {:ok, storages} = CacheQuery.from_server_get_storages(server)
@@ -149,7 +145,6 @@ defmodule Helix.Software.Action.Flow.FileTest do
 
       {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-      :timer.sleep(250)
       CacheHelper.sync_test()
 
       params = %{

--- a/test/software/event/decryptor_test.exs
+++ b/test/software/event/decryptor_test.exs
@@ -25,9 +25,6 @@ defmodule Helix.Software.Event.DecryptorTest do
 
       Event.emit(event)
 
-      # Let's give it enough time to run
-      :timer.sleep(100)
-
       target_file = Repo.get(File, target_file.file_id)
       refute target_file.crypto_version
     end
@@ -52,9 +49,6 @@ defmodule Helix.Software.Event.DecryptorTest do
 
       Event.emit(event)
 
-      # Let's give it enough time to run
-      :timer.sleep(100)
-
       new_keys = Enum.map(old_keys, &Repo.get(CryptoKey, &1.file_id))
 
       assert Enum.all?(new_keys, &is_nil(&1.target_file_id))
@@ -74,9 +68,6 @@ defmodule Helix.Software.Event.DecryptorTest do
       }
 
       Event.emit(event)
-
-      # Let's give it enough time to run
-      :timer.sleep(100)
 
       [key] = CryptoKeyInternal.get_on_storage(storage)
 

--- a/test/software/event/encryptor_test.exs
+++ b/test/software/event/encryptor_test.exs
@@ -26,9 +26,6 @@ defmodule Helix.Software.Event.EncryptorTest do
 
       Event.emit(event)
 
-      # Let's give it enough time to run
-      :timer.sleep(100)
-
       [key] = CryptoKeyInternal.get_on_storage(storage)
 
       assert target_file.file_id == key.target_file_id
@@ -47,9 +44,6 @@ defmodule Helix.Software.Event.EncryptorTest do
       }
 
       Event.emit(event)
-
-      # Let's give it enough time to run
-      :timer.sleep(100)
 
       target_file = Repo.get(File, target_file.file_id)
       assert event.version == target_file.crypto_version
@@ -76,9 +70,6 @@ defmodule Helix.Software.Event.EncryptorTest do
         |> Enum.map(fn {:ok, key} -> key end)
 
       Event.emit(event)
-
-      # Let's give it enough time to run
-      :timer.sleep(100)
 
       new_keys = Enum.map(old_keys, &Repo.get(CryptoKey, &1.file_id))
 

--- a/test/support/hell/setup.ex
+++ b/test/support/hell/setup.ex
@@ -8,7 +8,6 @@ defmodule HELL.TestHelper.Setup do
     account = AccountFactory.insert(:account)
     {:ok, %{server: server}} = AccountFlow.setup_account(account)
 
-    :timer.sleep(100)
     CacheHelper.purge_server(server.server_id)
 
     {server, account}


### PR DESCRIPTION
It will improve test execution time and reduce bugs.

Does so by making the execution of flow callbacks and events sequential and blocking (avoiding ecto sandbox error and ensuring that, on a test, as soon as a flow completes, every side-effect of it shall be completed).

On my rig this reduced the test length from 35-40s to 15-20s from removing the `:timer.sleep` workaround we were using to give the test time to cause the side-effects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/258)
<!-- Reviewable:end -->
