### PR TITLE
Join server channel using NIPs instead of ServerID

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -52,7 +52,7 @@
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},
-        {Credo.Check.Readability.PreferImplicitTry},
+        {Credo.Check.Readability.PreferImplicitTry, false},
         {Credo.Check.Readability.StringSigils, false},
         {Credo.Check.Readability.RedundantBlankLines},
         {Credo.Check.Readability.TrailingBlankLine, false},

--- a/lib/cache/state/purge_queue.ex
+++ b/lib/cache/state/purge_queue.ex
@@ -144,5 +144,4 @@ defmodule Helix.Cache.State.PurgeQueue do
     :ets.delete(@ets_table_name, {model, key, action})
     {:noreply, state}
   end
-
 end

--- a/lib/cache/state/queue_sync.ex
+++ b/lib/cache/state/queue_sync.ex
@@ -33,7 +33,6 @@ defmodule Helix.Cache.State.QueueSync do
     {:noreply, %{state | timer_ref: timer_ref}}
   end
 
-  defp schedule(interval) do
-    Process.send_after(@registry_name, :sync, interval)
-  end
+  defp schedule(interval),
+    do: Process.send_after(@registry_name, :sync, interval)
 end

--- a/lib/cache/state/supervisor.ex
+++ b/lib/cache/state/supervisor.ex
@@ -7,7 +7,7 @@ defmodule Helix.Cache.State.Supervisor do
   alias Helix.Cache.State.QueueSync, as: StateQueueSync
 
   @spec start_link() ::
-  Supervisor.on_start
+    Supervisor.on_start
   @doc false
   def start_link do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)

--- a/lib/event/notificable.ex
+++ b/lib/event/notificable.ex
@@ -96,6 +96,15 @@ defprotocol Helix.Event.Notificable do
 
   alias Phoenix.Socket
 
+  alias Helix.Account.Model.Account
+  alias Helix.Server.Model.Server
+
+  @type whom_to_notify ::
+    %{
+      optional(:server) => [Server.id],
+      optional(:account) => [Account.id]
+    }
+
   @spec generate_payload(event :: struct, Socket.t) ::
     {:ok, %{data: payload :: term, event: String.t}}
     | :noreply
@@ -122,7 +131,7 @@ defprotocol Helix.Event.Notificable do
   def generate_payload(event, socket)
 
   @spec whom_to_notify(event :: struct) ::
-    [String.t]
+    whom_to_notify
   @doc """
   Specifies which topics should receive the event.
 
@@ -141,18 +150,4 @@ defprotocol Helix.Event.Notificable do
   implementing for Account or other channels)
   """
   def whom_to_notify(event)
-end
-
-defmodule Helix.Event.Notificable.Helper do
-
-  alias Helix.Account.Model.Account
-  alias Helix.Entity.Model.Entity
-
-  def notify_account(entity_id = %Entity.ID{}),
-    do: topic_account(entity_id)
-  def notify_account(account_id = %Account.ID{}),
-    do: topic_account(account_id)
-
-  defp topic_account(id),
-    do: ["account:" <> to_string(id)]
 end

--- a/lib/event/notification_handler.ex
+++ b/lib/event/notification_handler.ex
@@ -1,10 +1,90 @@
 defmodule Helix.Event.NotificationHandler do
 
-  alias Helix.Event.Notificable
+  import HELL.MacroHelpers
 
+  alias HELL.Utils
+  alias Helix.Event.Notificable
+  alias Helix.Account.Model.Account
+  alias Helix.Entity.Model.Entity
+  alias Helix.Server.Model.Server
+  alias Helix.Server.State.Websocket.Channel, as: ServerWebsocketChannelState
+
+  @type channel_account_id :: Account.id | Entity.id
+
+  @doc """
+  Handler responsible for guiding the event through the Notificable flow. It
+  will query `Notificable.whom_to_notify` to know which channels should receive
+  the event. Then, this event is broadcasted to each channel.
+  """
   def notification_handler(event) do
     event
     |> Notificable.whom_to_notify()
+    |> channel_mapper()
     |> Enum.each(&(Helix.Endpoint.broadcast(&1, "event", event)))
   end
+
+  docp """
+  Interprets the return `Notificable.whom_to_notify/1` format, returning a list
+  of valid channel topics/names.
+  """
+  @spec channel_mapper(Notificable.whom_to_notify) ::
+    channels :: [String.t]
+  defp channel_mapper(whom_to_notify, acc \\ [])
+  defp channel_mapper(notify = %{server: servers}, acc) do
+    acc =
+      servers
+      |> Utils.ensure_list()
+      |> Enum.uniq()
+      |> get_server_channels()
+      |> List.flatten()
+      |> Kernel.++(acc)
+
+    channel_mapper(Map.delete(notify, :server), acc)
+  end
+
+  defp channel_mapper(notify = %{account: accounts}, acc) do
+    acc =
+      accounts
+      |> Utils.ensure_list()
+      |> Enum.uniq()
+      |> get_account_channels()
+      |> List.flatten()
+      |> Kernel.++(acc)
+
+    channel_mapper(Map.delete(notify, :account), acc)
+  end
+
+  defp channel_mapper(%{}, acc),
+    do: acc
+
+  @spec get_server_channels([Server.id] | Server.id) ::
+    channels :: [String.t]
+  defp get_server_channels(servers) when is_list(servers),
+    do: Enum.map(servers, &get_server_channels/1)
+  defp get_server_channels(server_id) do
+    server_channels = ServerWebsocketChannelState.list_open_channels(server_id)
+
+    if server_channels do
+      Enum.map(server_channels, fn channel ->
+        "server:"
+        |> concat(channel.network_id)
+        |> concat("@")
+        |> concat(channel.ip)
+        |> concat("#")
+        |> concat(channel.counter)
+      end)
+    else
+      []
+    end
+  end
+
+  @spec get_account_channels([channel_account_id] | channel_account_id) ::
+    channels :: [String.t]
+  defp get_account_channels(accounts) when is_list(accounts),
+    do: Enum.map(accounts, &get_account_channels/1)
+  defp get_account_channels(account_id),
+    do: ["account:" <> to_string(account_id)]
+
+  defp concat(a, b),
+    do: a <> to_string(b)
 end

--- a/lib/hell/hell/dev_tools.ex
+++ b/lib/hell/hell/dev_tools.ex
@@ -1,5 +1,5 @@
+# credo:disable-for-this-file
 defmodule HELL.DevTools do
-  # credo:disable-for-this-file
 
   defmodule Atoms do
     @moduledoc """
@@ -42,6 +42,18 @@ defmodule HELL.DevTools do
         _ ->
           []
       end
+    end
+  end
+
+  defmodule ETS do
+    @moduledoc """
+    ETS-related helper functions.
+    """
+
+    def dump_table(table) do
+      table
+      |> :ets.match_object(:'$1')
+      |> IO.inspect()
     end
   end
 end

--- a/lib/hell/hell/utils.ex
+++ b/lib/hell/hell/utils.ex
@@ -9,4 +9,15 @@ defmodule HELL.Utils do
 
   def date_before(seconds, precision \\ :second),
     do: date_after(-seconds, precision)
+
+  @doc """
+  Helper to ensure the given value is returned as a list.
+  """
+  def ensure_list(nil),
+    do: []
+  def ensure_list(value) when is_list(value),
+    do: value
+  def ensure_list(value),
+    do: [value]
+
 end

--- a/lib/log/model/log/events.ex
+++ b/lib/log/model/log/events.ex
@@ -21,10 +21,8 @@ defmodule Helix.Log.Model.Log.LogCreatedEvent do
       {:ok, return}
     end
 
-    def whom_to_notify(event) do
-      [event.server_id]
-      |> Enum.map(&("server:" <> to_string(&1)))
-    end
+    def whom_to_notify(event),
+      do: %{server: event.server_id}
   end
 end
 
@@ -51,10 +49,8 @@ defmodule Helix.Log.Model.Log.LogModifiedEvent do
       {:ok, return}
     end
 
-    def whom_to_notify(event) do
-      [event.server_id]
-      |> Enum.map(&("server:" <> to_string(&1)))
-    end
+    def whom_to_notify(event),
+      do: %{server: event.server_id}
   end
 end
 
@@ -81,9 +77,7 @@ defmodule Helix.Log.Model.Log.LogDeletedEvent do
       {:ok, return}
     end
 
-    def whom_to_notify(event) do
-      [event.server_id]
-      |> Enum.map(&("server:" <> to_string(&1)))
-    end
+    def whom_to_notify(event),
+      do: %{server: event.server_id}
   end
 end

--- a/lib/process/model/process/events.ex
+++ b/lib/process/model/process/events.ex
@@ -122,11 +122,8 @@ defmodule Helix.Process.Model.Process.ProcessCreatedEvent do
     Both gateway and destination are notified. If they are the same, obviously
     notifies only one.
     """
-    def whom_to_notify(event) do
-      [event.gateway_id, event.target_id]
-      |> Enum.uniq()
-      |> Enum.map(&("server:" <> to_string(&1)))
-    end
+    def whom_to_notify(event),
+      do: %{server: [event.gateway_id, event.target_id]}
   end
 end
 
@@ -161,10 +158,7 @@ defmodule Helix.Process.Model.Process.ProcessConclusionEvent do
       {:ok, return}
     end
 
-    def whom_to_notify(event) do
-      [event.gateway_id, event.target_id]
-      |> Enum.uniq()
-      |> Enum.map(&("server:" <> to_string(&1)))
-    end
+    def whom_to_notify(event),
+      do: %{server: [event.gateway_id, event.target_id]}
   end
 end

--- a/lib/server/model/events.ex
+++ b/lib/server/model/events.ex
@@ -55,10 +55,7 @@ defmodule Helix.Server.Model.Server.PasswordAcquiredEvent do
       {:ok, return}
     end
 
-    def whom_to_notify(event) do
-      [event.entity_id]
-      |> Enum.map(&("account:" <> to_string(&1)))
-    end
-
+    def whom_to_notify(event),
+      do: %{account: event.entity_id}
   end
 end

--- a/lib/server/query/server.ex
+++ b/lib/server/query/server.ex
@@ -35,7 +35,7 @@ defmodule Helix.Server.Query.Server do
       {:ok, nips} ->
         nips
         |> Enum.find(&(&1.network_id) == network_id)
-        |> Access.get(:ip)
+        |> Map.get(:ip)
       _ ->
         nil
     end

--- a/lib/server/state/supervisor.ex
+++ b/lib/server/state/supervisor.ex
@@ -1,0 +1,18 @@
+defmodule Helix.Server.State.Supervisor do
+
+  use Supervisor
+
+  alias Helix.Server.State.Websocket.Channel, as: ServerWebsocketChannelState
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    children = [
+      worker(ServerWebsocketChannelState, [])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/server/state/supervisor.ex
+++ b/lib/server/state/supervisor.ex
@@ -3,6 +3,7 @@ defmodule Helix.Server.State.Supervisor do
   use Supervisor
 
   alias Helix.Server.State.Websocket.Channel, as: ServerWebsocketChannelState
+  alias Helix.Server.State.Websocket.GC, as: ServerWebsocketGC
 
   def start_link do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
@@ -10,7 +11,8 @@ defmodule Helix.Server.State.Supervisor do
 
   def init(_) do
     children = [
-      worker(ServerWebsocketChannelState, [])
+      worker(ServerWebsocketChannelState, []),
+      worker(ServerWebsocketGC, [])
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/lib/server/state/websocket/gc.ex
+++ b/lib/server/state/websocket/gc.ex
@@ -1,0 +1,41 @@
+defmodule Helix.Server.State.Websocket.GC do
+  @moduledoc """
+  ServerWebsocketChannelState GC timer.
+
+  Every 30 minutes, or whatever is set to `@interval`, GC will be applied,
+  removing unused servers from the Server ETS table set at SerWSChannelState.
+  """
+
+  use GenServer
+
+  alias Helix.Server.State.Websocket.Channel, as: ServerWebsocketChannelState
+
+  @interval 30 * 60 * 1000  # 30 minutes
+  @registry_name :server_channel_gc
+
+  def start_link(interval \\ @interval),
+    do: GenServer.start_link(__MODULE__, interval, name: @registry_name)
+
+  def set_interval(interval),
+    do: GenServer.call(@registry_name, {:set_interval, interval})
+
+  def init(interval) do
+    timer_ref = schedule(interval)
+    {:ok, %{timer_ref: timer_ref, interval: interval}}
+  end
+
+  def handle_call({:set_interval, new_interval}, _from, state) do
+    Process.cancel_timer(state.timer_ref)
+    new_timer = schedule(new_interval)
+    {:reply, :ok, %{timer_ref: new_timer, interval: new_interval}}
+  end
+
+  def handle_info(:sync, state) do
+    ServerWebsocketChannelState.gc()
+    timer_ref = schedule(state.interval)
+    {:noreply, %{state | timer_ref: timer_ref}}
+  end
+
+  defp schedule(interval),
+    do: Process.send_after(@registry_name, :sync, interval)
+end

--- a/lib/server/supervisor.ex
+++ b/lib/server/supervisor.ex
@@ -3,6 +3,7 @@ defmodule Helix.Server.Supervisor do
   use Supervisor
 
   alias Helix.Server.Repo
+  alias Helix.Server.State.Supervisor, as: SupervisorState
 
   def start_link do
     Supervisor.start_link(__MODULE__, [])
@@ -10,9 +11,10 @@ defmodule Helix.Server.Supervisor do
 
   def init(_) do
     children = [
-      worker(Repo, [])
+      worker(Repo, []),
+      supervisor(SupervisorState, [])
     ]
 
-    supervise(children, strategy: :one_for_one)
+    supervise(children, strategy: :rest_for_one)
   end
 end

--- a/lib/server/websocket/channel/server.ex
+++ b/lib/server/websocket/channel/server.ex
@@ -29,9 +29,7 @@ defmodule Helix.Server.Websocket.Channel.Server do
 
   [#<counter>] denotes optional argument. If omitted, counter=0 will be assumed.
   """
-  # def join(topic = "server:" <> _ <> "@" <> _ <> "#" <> _, params, socket) do
   def join(topic = "server:" <> _, params, socket) do
-    # TODO: verify format
     access_type =
       if params["gateway_ip"] do
         :remote

--- a/lib/server/websocket/channel/server/join.ex
+++ b/lib/server/websocket/channel/server/join.ex
@@ -23,30 +23,75 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
 
   defimpl Helix.Websocket.Joinable do
 
+    alias HELL.IPv4
+
     alias Helix.Cache.Query.Cache, as: CacheQuery
     alias Helix.Entity.Query.Entity, as: EntityQuery
     alias Helix.Network.Model.Network
     alias Helix.Server.Model.Server
     alias Helix.Server.Henforcer.Channel, as: ChannelHenforcer
     alias Helix.Server.Public.Server, as: ServerPublic
+    alias Helix.Server.State.Websocket.Channel, as: ServerWebsocketChannelState
     alias Helix.Server.Websocket.Channel.Server.Join, as: ServerJoin
     alias Helix.Server.Websocket.Channel.Server.Join.Utils, as: ServerJoinUtils
+
+    defp get_topic_data("server:" <> topic) do
+      # Add default counter to the topic name, in case none was given
+      topic =
+        if String.contains?(topic, "#") do
+          topic
+        else
+          topic <> "#0"
+        end
+
+      # Below splits are equivalent to the following pattern match:
+      # `network_id <> "@" <> ip <> "#" <> counter`
+      # Unfortunately, pattern-matching on such string with variable byte size
+      # is not possible on erlang/elixir.
+      [network_id, topic] = String.split(topic, "@", parts: 2)
+      [ip, counter] = String.split(topic, "#", parts: 2)
+
+      try do
+        data =
+          %{
+            network_id: network_id,
+            ip: ip,
+            counter: String.to_integer(counter)
+          }
+
+        {:ok, data}
+      catch
+        _ ->
+          :error
+      end
+    end
 
     @doc """
     Verifies params for local server join.
     """
     def check_params(request = %ServerJoin{type: :local}, _socket) do
-      gateway_id = ServerJoinUtils.get_id_from_topic(request.topic)
-
       with \
-        {:ok, gateway_id} <- Server.ID.cast(gateway_id)
+        {:ok, data} = get_topic_data(request.topic),
+        {:ok, network_id} <- Network.ID.cast(data.network_id),
+        true <- IPv4.valid?(data.ip),
+        true <- data.counter >= 0,
+        {:ok, server_id} <-
+          CacheQuery.from_nip_get_server(network_id, data.ip)
       do
         params = %{
-          gateway_id: gateway_id
+          network_id: network_id,
+          gateway_ip: data.ip,
+          gateway_id: server_id,
+          counter: data.counter
         }
 
         {:ok, %{request| params: params}}
       else
+        # Fix when elixir-lang issue #6426 gets fixed
+        # :badserver ->
+        #   {:error, %{message: "nip_not_found"}}
+        {:error, {:nip, :notfound}} ->
+          {:error, %{message: "nip_not_found"}}
         _ ->
           {:error, %{message: "bad_request"}}
       end
@@ -56,24 +101,37 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
     Verifies params for remote server join.
     """
     def check_params(request = %ServerJoin{type: :remote}, _socket) do
-      destination_id = ServerJoinUtils.get_id_from_topic(request.topic)
+      gateway_ip = request.unsafe["gateway_ip"]
 
       with \
-        true <- not is_nil(request.unsafe["ip"]),
-        {:ok, gateway_id} <- Server.ID.cast(request.unsafe["gateway_id"]),
-        {:ok, destination_id} <- Server.ID.cast(destination_id),
-        {:ok, network_id} <- Network.ID.cast(request.unsafe["network_id"])
+        {:ok, data} = get_topic_data(request.topic),
+        {:ok, network_id} <- Network.ID.cast(data.network_id),
+        true <- IPv4.valid?(data.ip),
+        true <- IPv4.valid?(gateway_ip),
+        true <- data.counter >= 0,
+        true <- not is_nil(gateway_ip),
+        {:ok, gateway_id} <-
+          CacheQuery.from_nip_get_server(network_id, gateway_ip),
+        {:ok, destination_id} <-
+          CacheQuery.from_nip_get_server(network_id, data.ip)
       do
         params = %{
-          gateway_id: gateway_id,
-          destination_id: destination_id,
           network_id: network_id,
-          ip: request.unsafe["ip"],
+          gateway_id: gateway_id,
+          gateway_ip: gateway_ip,
+          destination_id: destination_id,
+          destination_ip: data.ip,
+          counter: data.counter,
           password: request.unsafe["password"]
         }
 
         {:ok, %{request| params: params}}
       else
+        # Fix when elixir-lang issue #6426 gets fixed
+        # :badserver ->
+        #   {:error, %{message: "nip_not_found"}}
+        # :internal ->
+        #   {:error, %{message: "internal"}}
         _ ->
           {:error, %{message: "bad_request"}}
       end
@@ -109,7 +167,7 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
       destination_id = request.params.destination_id
       password = request.params.password
       network_id = request.params.network_id
-      ip = request.params.ip
+      destination_ip = request.params.destination_ip
 
       with \
         :ok <- ChannelHenforcer.validate_gateway(entity_id, gateway_id),
@@ -118,7 +176,7 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
             destination_id,
             password,
             network_id,
-            ip)
+            destination_ip)
       do
         {:ok, request}
       else
@@ -128,29 +186,57 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
       end
     end
 
+    defp build_meta(request) do
+      access_type =
+        if Map.has_key?(request.params, :password) do
+          :remote
+        else
+          :local
+        end
+
+      %{
+        counter: request.params.counter,
+        network_id: request.params.network_id,
+        access_type: access_type
+      }
+    end
+
     @doc """
     Joins a local server. Note that when we've reached this point, previous
     permissions were already applied.
+
+    Once joined, we must update the ServerWebsocketChannelState database, which
+    is responsible for mapping NIPs to server IDs.
     """
     def join(request = %ServerJoin{type: :local}, socket, assign) do
+      entity_id = socket.assigns.entity_id
       gateway_id = request.params.gateway_id
+      gateway_ip = request.params.gateway_ip
+      network_id = request.params.network_id
+      counter = request.params.counter
 
-      with \
-        {:ok, nips} <- CacheQuery.from_server_get_nips(gateway_id)
-      do
-        gateway_data = %{
-          server_id: gateway_id,
-          entity_id: socket.assigns.entity_id,
-          ips: ServerJoinUtils.format_nips(nips)
-        }
-        socket =
-          socket
-          |> assign.(:access_type, :local)
-          |> assign.(:gateway, gateway_data)
-          |> assign.(:destination, gateway_data)
+      # Updates websocket state
+      ServerWebsocketChannelState.join(
+        entity_id,
+        gateway_id,
+        {network_id, gateway_ip},
+        counter
+      )
 
-        {:ok, socket}
-      end
+      gateway_data = %{
+        server_id: gateway_id,
+        entity_id: entity_id,
+        ip: gateway_ip
+      }
+
+      socket =
+        socket
+        |> assign.(:access_type, :local)
+        |> assign.(:gateway, gateway_data)
+        |> assign.(:destination, gateway_data)
+        |> assign.(:meta, build_meta(request))
+
+      {:ok, socket}
     end
 
     @doc """
@@ -159,17 +245,29 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
 
     Right before joining the remote server, an `ssh` connection is created
     between gateway and destination.
+
+    Once joined, we must update the ServerWebsocketChannelState database, which
+    is responsible for mapping NIPs to server IDs.
     """
     def join(request = %ServerJoin{type: :remote}, socket, assign) do
-      gateway_id = request.params.gateway_id
-      destination_id = request.params.destination_id
+      gateway_entity_id = socket.assigns.entity_id
       network_id = request.params.network_id
+      gateway_id = request.params.gateway_id
+      gateway_ip = request.params.gateway_ip
+      destination_id = request.params.destination_id
+      destination_ip = request.params.destination_ip
+      counter = request.params.counter
+
+      # Updates websocket state
+      ServerWebsocketChannelState.join(
+        gateway_entity_id,
+        destination_id,
+        {network_id, destination_ip},
+        counter
+      )
 
       with \
         destination_entity = %{} <- EntityQuery.fetch_by_server(destination_id),
-        {:ok, gateway_nips} <- CacheQuery.from_server_get_nips(gateway_id),
-        {:ok, destination_nips} <-
-          CacheQuery.from_server_get_nips(destination_id),
         {:ok, tunnel} <- ServerPublic.connect_to_server(
           gateway_id,
           destination_id,
@@ -177,23 +275,22 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
       do
         gateway_data = %{
           server_id: gateway_id,
-          entity_id: socket.assigns.entity_id,
-          ips: ServerJoinUtils.format_nips(gateway_nips)
+          entity_id: gateway_entity_id,
+          ip: gateway_ip
         }
 
         destination_data = %{
           server_id: destination_id,
           entity_id: destination_entity.entity_id,
-          ips: ServerJoinUtils.format_nips(destination_nips)
+          ip: destination_ip
         }
 
         socket =
           socket
-          |> assign.(:network_id, network_id)
           |> assign.(:tunnel, tunnel)
-          |> assign.(:access_type, :remote)
           |> assign.(:gateway, gateway_data)
           |> assign.(:destination, destination_data)
+          |> assign.(:meta, build_meta(request))
 
         {:ok, socket}
       end
@@ -201,30 +298,6 @@ defmodule Helix.Server.Websocket.Channel.Server.Join do
   end
 
   defmodule Utils do
-
-    @doc """
-    Helper to format NIPs to the expected socket assign format, which uses
-    `network_id` as index.
-
-    Example: 
-      [%{network_id: network_id, ip: ip}]  ---->  %{network_id: ip}
-    """
-    def format_nips(nips) do
-      nips
-      |> Enum.reduce(%{}, fn nip, acc ->
-        Map.put(acc, nip.network_id, nip.ip)
-      end)
-    end
-
-    @doc """
-    Gets the server ID from the specified topic.
-
-    Example:
-      "server:abcdef" -> "abcdef"
-    """
-    def get_id_from_topic(topic),
-      do: List.last(String.split(topic, "server:"))
-
     def format_error(object, reason),
       do: to_string(object) <> "_" <> to_string(reason)
   end

--- a/lib/server/websocket/channel/server/requests/bootstrap.ex
+++ b/lib/server/websocket/channel/server/requests/bootstrap.ex
@@ -14,7 +14,7 @@ defmodule Helix.Server.Websocket.Channel.Server.Requests.Bootstrap do
 
     def check_permissions(request, socket) do
 
-      if socket.assigns.access_type == :remote do
+      if socket.assigns.meta.access_type == :remote do
         {:ok, request}
       else
         {:error, %{message: "own_server_bootstrap"}}

--- a/lib/server/websocket/channel/server/requests/bruteforce.ex
+++ b/lib/server/websocket/channel/server/requests/bruteforce.ex
@@ -19,7 +19,7 @@ defmodule Helix.Server.Websocket.Channel.Server.Requests.Bruteforce do
           Network.ID.cast(request.unsafe["network_id"]),
         true <- IPv4.valid?(request.unsafe["ip"]),
         {:ok, bounces} = cast_bounces(request.unsafe["bounces"]),
-        true <- socket.assigns.access_type == :local || :bad_attack_src
+        true <- socket.assigns.meta.access_type == :local || :bad_attack_src
       do
         params = %{
           bounces: bounces,
@@ -39,7 +39,7 @@ defmodule Helix.Server.Websocket.Channel.Server.Requests.Bruteforce do
     def check_permissions(request, socket) do
       network_id = request.params.network_id
       source_id = socket.assigns.gateway.server_id
-      source_ip = socket.assigns.gateway.ips[network_id]
+      source_ip = socket.assigns.gateway.ip
       ip = request.params.ip
 
       can_bruteforce =
@@ -91,7 +91,7 @@ defmodule Helix.Server.Websocket.Channel.Server.Requests.Bruteforce do
         network_id: to_string(process.network_id),
         file_id: file_id,
         connection_id: connection_id,
-        source_ip: socket.assigns.gateway.ips[process.network_id],
+        source_ip: socket.assigns.gateway.ip,
         target_ip: request.params.ip
       }
 

--- a/lib/story/event/email.ex
+++ b/lib/story/event/email.ex
@@ -28,7 +28,6 @@ defmodule Helix.Story.Event.Email do
       """
 
       alias HELL.ClientUtils
-      alias Helix.Event.Notificable.Helper, as: NotificableHelper
 
       @event "story_email_sent"
 
@@ -47,7 +46,7 @@ defmodule Helix.Story.Event.Email do
       Notify the player on his own channel.
       """
       def whom_to_notify(event),
-        do: NotificableHelper.notify_account(event.entity_id)
+        do: %{account: event.entity_id}
     end
   end
 end

--- a/lib/story/event/reply.ex
+++ b/lib/story/event/reply.ex
@@ -25,7 +25,6 @@ defmodule Helix.Story.Event.Reply do
       @moduledoc false
 
       alias HELL.ClientUtils
-      alias Helix.Event.Notificable.Helper, as: NotificableHelper
 
       @event "story_reply_sent"
 
@@ -41,7 +40,7 @@ defmodule Helix.Story.Event.Reply do
       end
 
       def whom_to_notify(event),
-        do: NotificableHelper.notify_account(event.entity_id)
+        do: %{account: event.entity_id}
     end
   end
 end

--- a/lib/story/event/step.ex
+++ b/lib/story/event/step.ex
@@ -22,8 +22,6 @@ defmodule Helix.Story.Event.Step do
     defimpl Helix.Event.Notificable do
       @moduledoc false
 
-      alias Helix.Event.Notificable.Helper, as: NotificableHelper
-
       @event "story_step_proceeded"
 
       def generate_payload(event, _socket) do
@@ -39,7 +37,7 @@ defmodule Helix.Story.Event.Step do
       Notifies only the player
       """
       def whom_to_notify(event),
-        do: NotificableHelper.notify_account(event.entity_id)
+        do: %{account: event.entity_id}
     end
   end
 end

--- a/lib/story/model/step/macros.ex
+++ b/lib/story/model/step/macros.ex
@@ -9,6 +9,7 @@ defmodule Helix.Story.Model.Step.Macros do
   import HELL.MacroHelpers
 
   alias HELL.Constant
+  alias HELL.Utils
   alias Helix.Story.Model.Step
   alias Helix.Story.Action.Story, as: StoryAction
 
@@ -231,16 +232,6 @@ defmodule Helix.Story.Model.Step.Macros do
     get_contact(mission_contact, step_module)
   end
 
-  docp """
-  Helper to ensure the given value is returned as a list.
-  """
-  defp ensure_list(nil),
-    do: []
-  defp ensure_list(value) when is_list(value),
-    do: value
-  defp ensure_list(value),
-    do: [value]
-
   @spec add_email(Step.email_id, term) ::
     Step.emails
   docp """
@@ -250,8 +241,8 @@ defmodule Helix.Story.Model.Step.Macros do
   defp add_email(email_id, opts) do
     metadata = %{
       id: email_id,
-      replies: ensure_list(opts[:reply]),
-      locked: ensure_list(opts[:locked])
+      replies: Utils.ensure_list(opts[:reply]),
+      locked: Utils.ensure_list(opts[:locked])
     }
 
     Map.put(%{}, email_id, metadata)

--- a/test/cache/state/queue_sync_test.exs
+++ b/test/cache/state/queue_sync_test.exs
@@ -15,12 +15,8 @@ defmodule Helix.Cache.State.QueueSyncTest do
   end
 
   describe "queue sync" do
-    @tag :slow
     test "it syncs periodically", context do
       server_id = context.server.server_id
-
-      # Set QueueSync interval to 1s
-      StateQueueSync.set_interval(1000)
 
       # First query, will fetch from origin and add entry to PurgeQueue
       {:ok, _} = CacheQuery.from_server_get_all(server_id)
@@ -30,8 +26,9 @@ defmodule Helix.Cache.State.QueueSyncTest do
       # Nothing on the DB..
       assert_miss CacheInternal.direct_query(:server, server_id)
 
-      # But once we give it enough time to sync...
-      :timer.sleep(1100)
+      # Set QueueSync interval to 50ms & give it enough time
+      StateQueueSync.set_interval(50)
+      :timer.sleep(100)
 
       # ...it will be added to the DB
       assert_hit CacheInternal.direct_query(:server, server_id)

--- a/test/features/hack_test.exs
+++ b/test/features/hack_test.exs
@@ -34,7 +34,6 @@ defmodule Helix.Test.Features.Hack do
 
       {target, _} = ServerSetup.server()
 
-      {:ok, [source_nip]} = CacheQuery.from_server_get_nips(gateway.server_id)
       {:ok, [target_nip]} = CacheQuery.from_server_get_nips(target.server_id)
 
       SoftwareSetup.file([type: :cracker, server_id: gateway.server_id])

--- a/test/features/hack_test.exs
+++ b/test/features/hack_test.exs
@@ -13,6 +13,7 @@ defmodule Helix.Test.Features.Hack do
   alias Helix.Process.Query.Process, as: ProcessQuery
   alias Helix.Server.Websocket.Channel.Server, as: ServerChannel
 
+  alias Helix.Test.Channel.Helper, as: ChannelHelper
   alias Helix.Test.Channel.Setup, as: ChannelSetup
   alias Helix.Test.Process.TOPHelper
   alias Helix.Test.Software.Setup, as: SoftwareSetup
@@ -33,8 +34,8 @@ defmodule Helix.Test.Features.Hack do
 
       {target, _} = ServerSetup.server()
 
-      {:ok, [target_nip]} =
-        CacheQuery.from_server_get_nips(target.server_id)
+      {:ok, [source_nip]} = CacheQuery.from_server_get_nips(gateway.server_id)
+      {:ok, [target_nip]} = CacheQuery.from_server_get_nips(target.server_id)
 
       SoftwareSetup.file([type: :cracker, server_id: gateway.server_id])
 
@@ -94,12 +95,11 @@ defmodule Helix.Test.Features.Hack do
 
       # And I can actually login into the recently hacked server
 
-      topic = "server:" <> to_string(target.server_id)
+      topic =
+        ChannelHelper.server_topic_name(target_nip.network_id, target_nip.ip)
       params = %{
-        "gateway_id" => gateway.server_id,
-        "network_id" => target_nip.network_id,
-        "password" => password_acquired_event.data.password,
-        "ip" => target_nip.ip
+        "gateway_ip" => socket.assigns.gateway.ip,
+        "password" => password_acquired_event.data.password
       }
 
       {:ok, _, new_socket} =
@@ -123,8 +123,7 @@ defmodule Helix.Test.Features.Hack do
 
       {target, _} = ServerSetup.server()
 
-      {:ok, [target_nip]} =
-        CacheQuery.from_server_get_nips(target.server_id)
+      {:ok, [target_nip]} = CacheQuery.from_server_get_nips(target.server_id)
 
       # To the client, login consists of two steps:
       #  1 - Joining the remote server channel
@@ -132,12 +131,11 @@ defmodule Helix.Test.Features.Hack do
       # To the backend, `login` is simply the act of joining another server's
       # channel (step 1 above).
 
-      topic = "server:" <> to_string(target.server_id)
+      topic =
+        ChannelHelper.server_topic_name(target_nip.network_id, target_nip.ip)
       params = %{
-        "gateway_id" => gateway.server_id,
-        "network_id" => target_nip.network_id,
-        "password" => target.password,
-        "ip" => target_nip.ip
+        "gateway_ip" => socket.assigns.gateway.ip,
+        "password" => target.password
       }
 
       # So, let's login!

--- a/test/process/model/process/events_test.exs
+++ b/test/process/model/process/events_test.exs
@@ -4,27 +4,15 @@ defmodule Helix.Process.Model.Process.ProcessCreatedEventTest do
 
   alias Helix.Event.Notificable
 
-  alias Helix.Test.Channel.Helper, as: ChannelHelper
   alias Helix.Test.Channel.Setup, as: ChannelSetup
   alias Helix.Test.Event.Setup, as: EventSetup
 
   describe "Notificable.whom_to_notify/1" do
-    test "for single-server processes" do
-      event = EventSetup.process_created(:single_server)
-
-      assert [notification_server] = Notificable.whom_to_notify(event)
-
-      assert notification_server == ChannelHelper.to_topic(event.gateway_id)
-    end
-
-    test "for multi-server processes" do
+    test "servers are listed correctly" do
       event = EventSetup.process_created(:multi_server)
 
-      notification_list = Notificable.whom_to_notify(event)
-
-      assert notification_list ==
-        [ChannelHelper.to_topic(event.gateway_id),
-         ChannelHelper.to_topic(event.target_id)]
+      assert %{server: [event.gateway_id, event.target_id]} ==
+        Notificable.whom_to_notify(event)
     end
   end
 

--- a/test/server/state/websocket/gc_test.exs
+++ b/test/server/state/websocket/gc_test.exs
@@ -1,0 +1,33 @@
+defmodule Helix.Server.State.Websocket.GCTest do
+
+  use ExUnit.Case, async: true
+
+  alias Helix.Server.State.Websocket.Channel, as: ServerWebsocketChannelState
+  alias Helix.Server.State.Websocket.GC, as: ServerWebsocketGC
+
+  alias Helix.Test.Server.State.Helper, as: ServerStateHelper
+
+  describe "ServerWebsocketGC" do
+    test "it removes my trash every monday, wednesday and friday" do
+      # Scenario: Two players logged at one different server each
+      ServerWebsocketChannelState.join("e1", "s1", {"n", "ip1"}, 0)
+      ServerWebsocketChannelState.join("e2", "s2", {"n", "ip1"}, 0)
+
+      # We'll then remove `e1` and `e2` from `s1` and `s2`, respectively
+      ServerWebsocketChannelState.leave("e1", "s1", {"n", "ip1"}, 0)
+      ServerWebsocketChannelState.leave("e2", "s2", {"n", "ip1"}, 0)
+
+      # It's still there, since it hasn't being GCed
+      assert ServerStateHelper.lookup_server("s1")
+      assert ServerStateHelper.lookup_server("s2")
+
+      # We'll set GCTimer interval to 50ms & wait for it
+      ServerWebsocketGC.set_interval(50)
+      :timer.sleep(100)
+
+      # It's gone
+      refute ServerStateHelper.lookup_server("s1")
+      refute ServerStateHelper.lookup_server("s2")
+    end
+  end
+end

--- a/test/server/state/websocket/server_test.exs
+++ b/test/server/state/websocket/server_test.exs
@@ -297,7 +297,7 @@ defmodule Helix.Server.State.Websocket.ChannelTest do
       assert [channel] =
         ServerWebsocketChannelState.list_open_channels(server_id)
       assert channel.counter == 0
-      assert channel.network_id == to_string(network_id)
+      assert channel.network_id == network_id
       assert channel.ip == ip
     end
 

--- a/test/server/state/websocket/server_test.exs
+++ b/test/server/state/websocket/server_test.exs
@@ -1,0 +1,368 @@
+defmodule Helix.Server.State.Websocket.ChannelTest do
+
+  use ExUnit.Case, async: true
+
+  import HELL.MacroHelpers
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Network.Model.Network
+  alias Helix.Server.Model.Server
+  alias Helix.Server.State.Websocket.Channel, as: ServerWebsocketChannelState
+
+  alias HELL.TestHelper.Random
+  alias Helix.Test.Server.State.Helper, as: ServerStateHelper
+
+  defp generate_join do
+    entity_id = Entity.ID.generate()
+    server_id = Server.ID.generate()
+    network_id = Network.ID.generate()
+    ip = Random.ipv4()
+
+    {entity_id, server_id, {network_id, ip}}
+  end
+
+  defp join(sequence: total) do
+    {entity_id, server_id, nip} = generate_join()
+
+    0..(total - 1)
+    |> Enum.each(fn i ->
+      ServerWebsocketChannelState.join(entity_id, server_id, nip, i)
+    end)
+
+    {entity_id, server_id, nip}
+  end
+  defp join do
+    {entity_id, server_id, nip} = generate_join()
+
+    ServerWebsocketChannelState.join(entity_id, server_id, nip, 0)
+
+    {entity_id, server_id, nip, 0}
+  end
+
+  defp lookup_server(server_id),
+    do: ServerStateHelper.lookup_server(server_id) |> cast_server()
+
+  defp lookup_entity(entity_id),
+    do: ServerStateHelper.lookup_entity(entity_id) |> cast_entity()
+
+  defp cast_server(server),
+    do: ServerStateHelper.cast_server_entry(server)
+
+  defp cast_entity(entity),
+    do: ServerStateHelper.cast_entity_entry(entity)
+
+  docp """
+  Given a server entry, find its channels based on nip and counter
+  """
+  defp find_channels(server, nip = {_, _}) do
+    server.channels
+    |> Enum.filter(&({&1.network_id, &1.ip} == nip))
+    |> Enum.sort()
+  end
+
+  docp """
+  Given an entity entry, find its servers based on server_id, nip and counter
+  """
+  defp find_servers(entity, nip = {_, _}, counter) do
+    entity.servers
+    |> Enum.filter(&({&1.network_id, &1.ip} == nip and &1.counter == counter))
+    |> Enum.sort()
+  end
+  defp find_servers(entity, server_id, counter) do
+    entity.servers
+    |> Enum.filter(&(&1.server_id == server_id and &1.counter == counter))
+    |> Enum.sort()
+  end
+  defp find_servers(entity, nip = {_, _}) do
+    entity.servers
+    |> Enum.filter(&({&1.network_id, &1.ip} == nip))
+    |> Enum.sort()
+  end
+  defp find_servers(entity, server_id),
+    do: Enum.filter(entity.servers, &(&1.server_id == server_id)) |> Enum.sort()
+
+  describe "join/4" do
+    test "entity and servers entries are created" do
+      {entity_id, server_id, nip} = generate_join()
+
+      ServerWebsocketChannelState.join(entity_id, server_id, nip, 0)
+
+      server_entry = lookup_server(server_id)
+      assert server_entry.server_id == server_id
+
+      [channel] = find_channels(server_entry, nip)
+      assert channel.counter == 0
+      assert {channel.network_id, channel.ip} == nip
+
+      entity_entry = lookup_entity(entity_id)
+      assert entity_entry.entity_id == entity_id
+
+      [server] = find_servers(entity_entry, server_id)
+      assert server.server_id == server_id
+      assert server.counter == 0
+      assert {server.network_id, server.ip} == nip
+    end
+
+    test "entity joining the same server multiple times" do
+      {entity_id, server_id, nip = {network_id, ip}} = generate_join()
+
+      ServerWebsocketChannelState.join(entity_id, server_id, nip, 0)
+      ServerWebsocketChannelState.join(entity_id, server_id, nip, 1)
+      ServerWebsocketChannelState.join(entity_id, server_id, nip, 2)
+
+      server_entry = lookup_server(server_id)
+      assert server_entry.server_id == server_id
+
+      channels = [c1, c2, c3] = find_channels(server_entry, nip)
+
+      assert c1.counter == 0
+      assert c2.counter == 1
+      assert c3.counter == 2
+
+      assert Enum.all?(channels, &(&1.ip == ip))
+      assert Enum.all?(channels, &(&1.network_id == network_id))
+
+      entity_entry = lookup_entity(entity_id)
+      assert entity_entry.entity_id == entity_id
+
+      servers = [s1, s2, s3] = find_servers(entity_entry, server_id)
+      assert s1.counter == 0
+      assert s2.counter == 1
+      assert s3.counter == 2
+
+      assert Enum.all?(servers, &(&1.network_id == network_id))
+      assert Enum.all?(servers, &(&1.ip == ip))
+    end
+
+    test "multiple entities joining the same server" do
+      {e1_id, server_id, nip} = generate_join()
+      {e2_id, _, _} = generate_join()
+
+      ServerWebsocketChannelState.join(e1_id, server_id, nip, 0)
+      ServerWebsocketChannelState.join(e2_id, server_id, nip, 0)
+
+      # Only one channel is created
+      server_entry = lookup_server(server_id)
+      assert [_channel] = find_channels(server_entry, nip)
+
+      # One entry to `e1`
+      e1_entry = lookup_entity(e1_id)
+      assert [_server] = find_servers(e1_entry, server_id)
+
+      # One entry to `e2`
+      e2_entry = lookup_entity(e2_id)
+      assert [_server] = find_servers(e2_entry, server_id)
+    end
+  end
+
+  describe "leave/4" do
+    test "removes entity entry from database*" do
+      {entity_id, server_id, nip, counter} = join()
+
+      assert lookup_server(server_id)
+      assert lookup_entity(entity_id)
+
+      ServerWebsocketChannelState.leave(entity_id, server_id, nip, counter)
+
+      refute lookup_entity(entity_id)
+
+      # Server is still there, because it's remove asynchronously. See `gc/0`
+      assert lookup_server(server_id)
+    end
+
+    test "removing one entry won't affect others" do
+      {entity_id, server_id, nip} = join(sequence: 2)
+
+      assert lookup_server(server_id)
+      assert lookup_entity(entity_id)
+
+      ServerWebsocketChannelState.leave(entity_id, server_id, nip, 1)
+
+      # Removed the one with counter `1`, counter `0` is still there
+      entry_entity = lookup_entity(entity_id)
+      assert [_server] = find_servers(entry_entity, nip, 0)
+      assert [] == find_servers(entry_entity, nip, 1)
+    end
+
+    test "removing greater counter first" do
+      {entity_id, server_id, nip} = join(sequence: 2)
+
+      assert lookup_server(server_id)
+      assert lookup_entity(entity_id)
+
+      ServerWebsocketChannelState.leave(entity_id, server_id, nip, 0)
+
+      entry_entity = lookup_entity(entity_id)
+      assert [_server] = find_servers(entry_entity, nip, 1)
+      assert [] == find_servers(entry_entity, nip, 0)
+    end
+  end
+
+  describe "gc/0" do
+    test "removes unused servers" do
+      # Scenario: `e1` is connected twice to `s1`. `e2` is connected once to
+      # `s2`, and once to `s1`
+      {e1_id, s1_id, s1_nip} = join(sequence: 2)
+      {e2_id, s2_id, s2_nip, _} = join()
+
+      ServerWebsocketChannelState.join(e2_id, s1_id, s1_nip, 0)
+
+      # Save the entries before running `gc/0` for the first time
+      entry_s1_before = lookup_server(s1_id)
+      entry_s2_before = lookup_server(s2_id)
+
+      # Run garbage collector. Nothing should happen, as the entities are still
+      # active on the servers
+      ServerWebsocketChannelState.gc()
+
+      # Nothing changed
+      assert lookup_server(s1_id) == entry_s1_before
+      assert lookup_server(s2_id) == entry_s2_before
+
+      # `e2` leaves `s2`. Now no one is connected to `s2`
+      ServerWebsocketChannelState.leave(e2_id, s2_id, s2_nip, 0)
+
+      # `s2` is still there, since garbage collector hasn't run yet
+      assert lookup_server(s2_id) == entry_s2_before
+
+      # Run gc
+      ServerWebsocketChannelState.gc()
+
+      # Bad bad `s2` server no donut for you
+      refute lookup_server(s2_id)
+
+      # `e1` leaves `s1` once, so does `e2`
+      ServerWebsocketChannelState.leave(e1_id, s1_id, s1_nip, 0)
+      ServerWebsocketChannelState.leave(e2_id, s1_id, s1_nip, 0)
+
+      # Run gc
+      ServerWebsocketChannelState.gc()
+
+      # `s1` still exists because of `e1` connection with counter 0
+      entry_s1 = lookup_server(s1_id)
+
+      # Notice something interesting: `s1` still lists as it had two channels,
+      # when right now only one of them is being used (e1_id with counter 1),
+      # so `gc` could have deleted channel with counter 0 completely.
+      # That's not done currently for, uh, "simplification purposes".
+      # A server entry is only gc'd if literally no one is joined to it.
+      assert length(entry_s1.channels) == 2
+
+      # Finally, remove the last connection to it
+      ServerWebsocketChannelState.leave(e1_id, s1_id, s1_nip, 1)
+
+      # Run gc
+      ServerWebsocketChannelState.gc()
+
+      # It's gone
+      refute lookup_server(s1_id)
+    end
+  end
+
+  describe "invalidate_server/2" do
+    test "removes server and entity entries" do
+      # Scenario: One server with two players logged into it. One extra server
+      # joined by `e2` which should remain unaffected
+      {e1_id, s1_id, s1_nip, _} = join()
+      {e2_id, s2_id, _, _} = join()
+      ServerWebsocketChannelState.join(e2_id, s1_id, s1_nip, 0)
+
+      # Everything is fa-aine
+      assert lookup_server(s1_id)
+      assert lookup_server(s2_id)
+      assert lookup_entity(e1_id)
+      assert lookup_entity(e2_id)
+
+      # Force invalidation of `s1_id`
+      ServerWebsocketChannelState.invalidate_server(s1_id, s1_nip)
+
+      # `s1` no longer exists. `e1` is gone too, since `s1` was the only server
+      # it was logged into.
+      refute lookup_server(s1_id)
+      refute lookup_entity(e1_id)
+
+      # `e2` and `s2` still exist because they are in use.
+      assert lookup_server(s2_id)
+      assert lookup_entity(e2_id)
+    end
+  end
+
+  describe "list_open_channels/1" do
+    test "multiple entities, one channel" do
+      {_, server_id, nip = {network_id, ip}, _} = join()
+      ServerWebsocketChannelState.join("e2", server_id, nip, 0)
+      ServerWebsocketChannelState.join("e3", server_id, nip, 0)
+      ServerWebsocketChannelState.join("e4", server_id, nip, 0)
+
+      assert [channel] =
+        ServerWebsocketChannelState.list_open_channels(server_id)
+      assert channel.counter == 0
+      assert channel.network_id == to_string(network_id)
+      assert channel.ip == ip
+    end
+
+    test "multiple channels" do
+      {_, server_id, nip} = join(sequence: 4)
+      ServerWebsocketChannelState.join("e2", server_id, nip, 0)
+      ServerWebsocketChannelState.join("e3", server_id, nip, 0)
+      ServerWebsocketChannelState.join("e4", server_id, nip, 0)
+
+      channels = ServerWebsocketChannelState.list_open_channels(server_id)
+      assert length(channels) == 4
+    end
+
+    test "unlisted server" do
+      server_id = Server.ID.generate()
+      refute ServerWebsocketChannelState.list_open_channels(server_id)
+    end
+  end
+
+  describe "get_next_counter/3" do
+    test "first server being joined" do
+      next = ServerWebsocketChannelState.get_next_counter("e", "s", {"n", "ip"})
+      assert next == 0
+    end
+
+    test "different nip on same server" do
+      {entity_id, server_id, _, 0} = join()
+
+      next =
+        ServerWebsocketChannelState.get_next_counter(
+          entity_id,
+          server_id,
+          {"n", "ip"}
+        )
+
+      assert next == 0
+    end
+
+    test "second server being joined (ordered)" do
+      {entity_id, server_id, nip, 0} = join()
+
+      next =
+        ServerWebsocketChannelState.get_next_counter(entity_id, server_id, nip)
+      assert next == 1
+
+      # De novo, de novo
+      ServerWebsocketChannelState.join(entity_id, server_id, nip, next)
+
+      next =
+        ServerWebsocketChannelState.get_next_counter(entity_id, server_id, nip)
+      assert next == 2
+    end
+
+    test "next counter with gap" do
+      # Scenario: We'll create a sequence (counters 0 and 1), and them leave
+      # from counter 0 while keeping counter 1 active. The next login should
+      # use counter 0
+      {entity_id, server_id, nip} = join(sequence: 2)
+
+      # Leave counter 0
+      ServerWebsocketChannelState.leave(entity_id, server_id, nip, 0)
+
+      next =
+        ServerWebsocketChannelState.get_next_counter(entity_id, server_id, nip)
+      assert next == 0
+    end
+  end
+end

--- a/test/story/event/email_test.exs
+++ b/test/story/event/email_test.exs
@@ -4,7 +4,6 @@ defmodule Helix.Story.Event.EmailTest do
 
   alias Helix.Event.Notificable
 
-  alias Helix.Test.Channel.Helper, as: ChannelHelper
   alias Helix.Test.Channel.Setup, as: ChannelSetup
   alias Helix.Test.Event.Setup, as: EventSetup
 
@@ -12,8 +11,8 @@ defmodule Helix.Story.Event.EmailTest do
     test "notifies only the player" do
       event = EventSetup.Story.email_sent()
 
-      notification_list = Notificable.whom_to_notify(event)
-      assert notification_list == [ChannelHelper.to_topic(event.entity_id)]
+      notify = Notificable.whom_to_notify(event)
+      assert notify == %{account: event.entity_id}
     end
   end
 

--- a/test/story/event/reply_test.exs
+++ b/test/story/event/reply_test.exs
@@ -4,15 +4,15 @@ defmodule Helix.Story.Event.ReplyTest do
 
   alias Helix.Event.Notificable
 
-  alias Helix.Test.Channel.Helper, as: ChannelHelper
   alias Helix.Test.Channel.Setup, as: ChannelSetup
   alias Helix.Test.Event.Setup, as: EventSetup
 
   describe "Notificable.whom_to_notify/1" do
     event = EventSetup.Story.reply_sent()
 
-    notification_list = Notificable.whom_to_notify(event)
-    assert notification_list == [ChannelHelper.to_topic(event.entity_id)]
+    notify = Notificable.whom_to_notify(event)
+
+    assert notify == %{account: event.entity_id}
   end
 
   describe "Notificable.generate_payload/2" do

--- a/test/story/event/step_test.exs
+++ b/test/story/event/step_test.exs
@@ -4,7 +4,6 @@ defmodule Helix.Story.Event.Step.ProceededTest do
 
   alias Helix.Event.Notificable
 
-  alias Helix.Test.Channel.Helper, as: ChannelHelper
   alias Helix.Test.Channel.Setup, as: ChannelSetup
   alias Helix.Test.Event.Setup, as: EventSetup
 
@@ -12,8 +11,8 @@ defmodule Helix.Story.Event.Step.ProceededTest do
     test "notifies only the player" do
       event = EventSetup.Story.step_proceeded()
 
-      notification_list = Notificable.whom_to_notify(event)
-      assert notification_list == [ChannelHelper.to_topic(event.entity_id)]
+      notify = Notificable.whom_to_notify(event)
+      assert notify == %{account: event.entity_id}
     end
   end
 

--- a/test/support/channel/helper.ex
+++ b/test/support/channel/helper.ex
@@ -1,13 +1,9 @@
 defmodule Helix.Test.Channel.Helper do
 
-  alias Helix.Account.Model.Account
-  alias Helix.Entity.Model.Entity
-  alias Helix.Server.Model.Server
+  def server_topic_name(network_id, ip, counter \\ 0) do
+    network_id = to_string(network_id)
+    counter = to_string(counter)
 
-  def to_topic(server_id = %Server.ID{}),
-    do: "server:" <> to_string(server_id)
-  def to_topic(account_id = %Account.ID{}),
-    do: "account:" <> to_string(account_id)
-  def to_topic(entity_id = %Entity.ID{}),
-    do: "account:" <> to_string(entity_id)
+    "server:" <> network_id <> "@" <> ip <> "#" <> counter
+  end
 end

--- a/test/support/channel/setup.ex
+++ b/test/support/channel/setup.ex
@@ -3,6 +3,8 @@ defmodule Helix.Test.Channel.Setup do
   import Phoenix.ChannelTest
 
   alias Helix.Websocket.Socket
+  alias Helix.Account.Model.Account
+  alias Helix.Account.Query.Account, as: AccountQuery
   alias Helix.Account.Websocket.Channel.Account, as: AccountChannel
   alias Helix.Entity.Model.Entity
   alias Helix.Server.Query.Server, as: ServerQuery
@@ -22,6 +24,7 @@ defmodule Helix.Test.Channel.Setup do
 
   @doc """
   - account: Specify which account to generate the socket to
+  - entity_id: Specify entity ID that socket should be generated to.
   - with_server: Whether to generate an account with server. Defaults to true.
 
   Related: Account.t, Server.t (when `with_server` is true)
@@ -31,6 +34,10 @@ defmodule Helix.Test.Channel.Setup do
       cond do
         opts[:with_server] ->
           AccountSetup.account([with_server: true])
+        opts[:entity_id] ->
+          account_id = Account.ID.cast!(to_string(opts[:entity_id]))
+          account = AccountQuery.fetch(account_id)
+          {account, %{}}
         opts[:account] ->
           {opts[:account], %{}}
         true ->

--- a/test/support/channel/setup.ex
+++ b/test/support/channel/setup.ex
@@ -4,17 +4,21 @@ defmodule Helix.Test.Channel.Setup do
 
   alias Helix.Websocket.Socket
   alias Helix.Account.Websocket.Channel.Account, as: AccountChannel
-  alias Helix.Cache.Query.Cache, as: CacheQuery
   alias Helix.Entity.Model.Entity
+  alias Helix.Server.Query.Server, as: ServerQuery
   alias Helix.Server.Websocket.Channel.Server, as: ServerChannel
 
   alias Helix.Test.Account.Setup, as: AccountSetup
   alias Helix.Test.Cache.Helper, as: CacheHelper
   alias Helix.Test.Entity.Setup, as: EntitySetup
+  alias Helix.Test.Network.Helper, as: NetworkHelper
   alias Helix.Test.Server.Setup, as: ServerSetup
   alias Helix.Test.Software.Setup, as: SoftwareSetup
+  alias Helix.Test.Channel.Helper, as: ChannelHelper
 
   @endpoint Helix.Endpoint
+
+  @internet_id NetworkHelper.internet_id()
 
   @doc """
   - account: Specify which account to generate the socket to
@@ -81,6 +85,7 @@ defmodule Helix.Test.Channel.Setup do
   - socket: Whether to reuse an existing socket.
   - own_server: Whether joining player's own server. No destination is created.
   - network_id: Specify network id. Not used if `own_server`
+  - counter: Specify counter (used by ServerWebsocketChannelState). Default is 0
   - bounces: List of bounces between each server. Not used if `own_server`.
     Expected type: [Server.id] TODO
   - gateway_files: Whether to generate random files on gateway. Defaults to
@@ -89,77 +94,99 @@ defmodule Helix.Test.Channel.Setup do
     to false.
 
   Related:
-    Account.t, gateway :: Server.t, destination :: Server.t | nil, \
+    Account.t, \
+    gateway :: Server.t, \
+    destination :: Server.t | nil, \
     destination_files :: [SoftwareSetup.file] | nil, \
-    gateway_files :: [SoftwareSetup.file] | nil,
+    gateway_files :: [SoftwareSetup.file] | nil, \
+    gateway_ip :: Network.ip, \
+    destination_ip :: Network.ip | nil
   """
-  def join_server(opts \\ [])
-  def join_server(opts = [own_server: true]) do
+  def join_server(opts \\ []) do
     {socket, %{account: account, server: gateway}} = create_socket()
 
-    gateway_id = to_string(gateway.server_id)
+    local? = Keyword.get(opts, :own_server, false)
 
-    topic = "server:" <> gateway_id
-    join_params = %{
-      "gateway_id" => gateway_id
-    }
+    {join, destination} =
+      if local? do
+        join = get_join_data(opts, gateway)
+
+        {join, nil}
+      else
+        {destination, _} = ServerSetup.server()
+        join = get_join_data(opts, gateway, destination)
+
+        {join, destination}
+      end
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, ServerChannel, join.topic, join.params)
 
     gateway_files = generate_files(opts[:gateway_files], gateway.server_id)
 
-    {:ok, _, socket} =
-      subscribe_and_join(socket, ServerChannel, topic, join_params)
-
-    related = %{
+    gateway_related = %{
       account: account,
       gateway: gateway,
-      gateway_files: gateway_files
+      gateway_ip: join.gateway_ip,
+      gateway_files: gateway_files,
     }
+
+    destination_related =
+      if local? do
+        %{}
+      else
+        destination_files =
+          generate_files(opts[:destination_files], destination.server_id)
+
+        %{
+          destination: destination,
+          destination_ip: join.destination_ip,
+          destination_files: destination_files
+        }
+      end
+
+    related = Map.merge(gateway_related, destination_related)
 
     CacheHelper.sync_test()
 
     {socket, related}
   end
 
-  def join_server(opts) do
-    {socket, %{account: account, server: gateway}} = create_socket()
+  defp get_join_data(opts, gateway, destination \\ false) do
+    network_id = Keyword.get(opts, :network_id, @internet_id)
 
-    {destination, _} = ServerSetup.server()
+    gateway_ip = ServerQuery.get_ip(gateway.server_id, network_id)
+    destination_ip =
+      if destination do
+        ServerQuery.get_ip(destination.server_id, network_id)
+      else
+        gateway_ip
+      end
 
-    gateway_id = to_string(gateway.server_id)
-    destination_id = to_string(destination.server_id)
-    network_id = Access.get(opts, :network_id, "::")
+    counter =
+      opts
+      |> Keyword.get(:counter, 0)
+      |> to_string()
 
-    {:ok, [target_nip]} = CacheQuery.from_server_get_nips(destination.server_id)
+    params =
+      if destination do
+        %{
+          "gateway_ip" => gateway_ip,
+          "password" => destination.password
+        }
+      else
+        %{}
+      end
 
-    # bounces = Access.get(opts, :bounces, [])
+    topic = ChannelHelper.server_topic_name(network_id, destination_ip, counter)
 
-    topic = "server:" <> destination_id
-    join_params = %{
-      "gateway_id" => gateway_id,
-      "network_id" => network_id,
-      "password" => destination.password,
-      "ip" => target_nip.ip
-      # bounces: bounces_string
+    %{
+      topic: topic,
+      gateway_ip: gateway_ip,
+      destination_ip: destination_ip,
+      network_id: network_id,
+      params: params
     }
-
-    gateway_files = generate_files(opts[:gateway_files], gateway.server_id)
-    destination_files =
-      generate_files(opts[:destination_files], destination.server_id)
-
-    {:ok, _, socket} =
-      subscribe_and_join(socket, ServerChannel, topic, join_params)
-
-    related = %{
-      account: account,
-      gateway: gateway,
-      destination: destination,
-      destination_files: destination_files,
-      gateway_files: gateway_files
-    }
-
-    CacheHelper.sync_test()
-
-    {socket, related}
   end
 
   defp generate_files(condition, server_id) do

--- a/test/support/server/state/helper.ex
+++ b/test/support/server/state/helper.ex
@@ -1,0 +1,67 @@
+defmodule Helix.Test.Server.State.Helper do
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Network.Model.Network
+  alias Helix.Server.Model.Server
+
+  @ets_table_server :ets_server_websocket_channel_server
+  @ets_table_entity :ets_server_websocket_channel_entity
+
+  def lookup_server(server_id) do
+    @ets_table_server
+    |> :ets.lookup(to_string(server_id))
+    |> result_or_false()
+  end
+
+  def lookup_entity(entity_id) do
+    @ets_table_entity
+    |> :ets.lookup(to_string(entity_id))
+    |> result_or_false()
+  end
+
+  defp result_or_false([]),
+    do: false
+  defp result_or_false([result]),
+    do: result
+
+  def cast_server_entry(false),
+    do: false
+  def cast_server_entry(entry) do
+    {server_id, entry_channels} = entry
+
+    channels =
+      Enum.map(entry_channels, fn {{network_id, ip}, counter} ->
+        %{
+          network_id: Network.ID.cast!(network_id),
+          ip: ip,
+          counter: counter
+        }
+      end)
+
+    %{
+      server_id: Server.ID.cast!(server_id),
+      channels: channels
+    }
+  end
+
+  def cast_entity_entry(false),
+    do: false
+  def cast_entity_entry(entry) do
+    {entity_id, entry_servers} = entry
+
+    servers =
+      Enum.map(entry_servers, fn {server_id, {network_id, ip}, counter} ->
+        %{
+          server_id: Server.ID.cast!(server_id),
+          network_id: Network.ID.cast!(network_id),
+          ip: ip,
+          counter: counter
+        }
+      end)
+
+    %{
+      entity_id: Entity.ID.cast!(entity_id),
+      servers: servers
+    }
+  end
+end

--- a/test/websocket/socket_test.exs
+++ b/test/websocket/socket_test.exs
@@ -11,14 +11,20 @@ defmodule Helix.Websocket.SocketTest do
 
   @endpoint Helix.Endpoint
 
-  test "socket is NOT connectable by anyone" do
-    assert :error = connect(Socket, %{})
-  end
+  describe "socket access" do
+    test "connection with valid token is allowed" do
+      account = AccountFactory.insert(:account)
+      {:ok, token} = SessionAction.generate_token(account)
 
-  test "socket is connectable only with valid token" do
-    account = AccountFactory.insert(:account)
-    {:ok, token} = SessionAction.generate_token(account)
+      assert {:ok, _} = connect(Socket, %{"token" => token})
+    end
 
-    assert {:ok, _} = connect(Socket, %{"token" => token})
+    test "'public' connection is refused" do
+      assert :error = connect(Socket, %{})
+    end
+
+    test "connection with wrong token is refused" do
+      assert :error = connect(Socket, %{"token" => "invalid"})
+    end
   end
 end


### PR DESCRIPTION
Depends on #267 

- [x] Websocket Channel State, mapping NIPs to ServerID
  - [x] Interface
  - [x] Tests
  - [x] Docs
- [x] Modify Server Joinable
- [x] Modify tests

Closes #273 

TODO:

- [x] Timer for ChannelState server garbage collector
- [x] Automatically grab next counter unless explicitly set during join
- [x] Typespecs on `ChannelState`

---

Incidental:

- DevTools.ETS
- Changed `Notificable.whom_to_notify` return format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/276)
<!-- Reviewable:end -->
#