### PR TITLE
Filesystem events

### DIFF
--- a/lib/event/dispatcher.ex
+++ b/lib/event/dispatcher.ex
@@ -150,6 +150,7 @@ defmodule Helix.Event.Dispatcher do
   event SoftwareEvent.Cracker.Bruteforce.Failed
   event SoftwareEvent.Cracker.Bruteforce.Processed
   event SoftwareEvent.Cracker.Overflow.Processed
+  event SoftwareEvent.File.Added
   event SoftwareEvent.File.Downloaded
   event SoftwareEvent.File.DownloadFailed
   event SoftwareEvent.File.Uploaded
@@ -168,6 +169,14 @@ defmodule Helix.Event.Dispatcher do
   event SoftwareEvent.Cracker.Overflow.Processed,
     SoftwareHandler.Cracker,
     :overflow_conclusion
+
+  event SoftwareEvent.File.Downloaded,
+    SoftwareHandler.Filesystem,
+    :filesystem_handler
+
+  event SoftwareEvent.File.Uploaded,
+    SoftwareHandler.Filesystem,
+    :filesystem_handler
 
   event SoftwareEvent.File.Transfer.Processed,
     SoftwareHandler.File.Transfer,

--- a/lib/software/event/handler/filesystem.ex
+++ b/lib/software/event/handler/filesystem.ex
@@ -1,0 +1,35 @@
+defmodule Helix.Software.Event.Handler.Filesystem do
+  @moduledoc """
+  This is the Hacker Experience's equivalent of `inotify(7)`
+  """
+
+  alias Helix.Event
+  alias Helix.Server.Model.Server
+  alias Helix.Software.Model.File
+
+  alias Helix.Software.Event.File.Added, as: FileAddedEvent
+  alias Helix.Software.Event.File.Downloaded, as: FileDownloadedEvent
+  alias Helix.Software.Event.File.Uploaded, as: FileUploadedEvent
+
+  # New entries
+
+  def filesystem_handler(event = %FileDownloadedEvent{}),
+    do: notify_new(event.file, event.to_server_id, event)
+
+  def filesystem_handler(event = %FileUploadedEvent{}),
+    do: notify_new(event.file, event.to_server_id, event)
+
+  # Existing entries being updated
+
+  # Existing entries being removed
+
+  # Generic notifiers
+
+  @spec notify_new(File.t, Server.id, Event.t) ::
+    term
+  defp notify_new(file = %File{}, server_id = %Server.ID{}, event) do
+    file
+    |> FileAddedEvent.new(server_id)
+    |> Event.emit(from: event)
+  end
+end

--- a/lib/software/model/file.ex
+++ b/lib/software/model/file.ex
@@ -60,7 +60,6 @@ defmodule Helix.Software.Model.File do
   @creation_fields ~w/name path storage_id file_size software_type/a
   @update_fields ~w/crypto_version/a
   @castable_fields ~w/name path/a
-
   @required_fields ~w/name path file_size software_type storage_id/a
 
   @software_types Software.Type.all()

--- a/test/support/channel/macros.ex
+++ b/test/support/channel/macros.ex
@@ -1,0 +1,34 @@
+defmodule Helix.Test.Channel.Macros do
+
+  defmacro wait_events(events) do
+    events = Enum.map(events, &to_string/1)
+    quote do
+      all_events = unquote(wait_all())
+
+      Enum.reduce(unquote(events), [], fn event, acc ->
+        case Enum.find(all_events, &(&1.event == event)) do
+          e = %{} ->
+            acc ++ [e]
+
+          nil ->
+            flunk("I did not receive the event \"#{event}\".")
+        end
+      end)
+
+    end
+  end
+
+  def wait_all do
+    quote do
+      Enum.reduce_while(1..10, [], fn _, acc ->
+        receive do
+          %Phoenix.Socket.Message{event: "event", payload: event} ->
+            {:cont, acc ++ [event]}
+
+          after
+            50 -> {:halt, acc}
+        end
+      end)
+    end
+  end
+end

--- a/test/support/channel/macros.ex
+++ b/test/support/channel/macros.ex
@@ -1,5 +1,9 @@
 defmodule Helix.Test.Channel.Macros do
 
+  @doc """
+  The `wait_events` helper will wait for the requested events in a deterministic
+  way, i.e. it doesn't matter the order they arrived.
+  """
   defmacro wait_events(events) do
     events = Enum.map(events, &to_string/1)
     quote do


### PR DESCRIPTION
Closes #327. Closes #321.

- [x] FileAddedEvent
- FileModifiedEvent[1]
- FileDeletedEvent[1]

[1] - Actually I'll be lazy and only create `FileAddedEvent` for now.

#### Incidental

- `wait_events` macro used to deterministically wait for events (regardless of the order they are received).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/330)
<!-- Reviewable:end -->
