### PR TITLE
Top improvements

### DIFF
--- a/lib/process/action/top.ex
+++ b/lib/process/action/top.ex
@@ -165,8 +165,14 @@ defmodule Helix.Process.Action.TOP do
 
     # Based on the return of `checkpoint` above, we've accumulated all processes
     # that should be updated. They will be passed to `handle_checkpoint`, which
-    # shall be responsible of properly handling this update in a transaction.
-    hespawn(fn -> handle_checkpoint(processes_to_update) end)
+    # shall be responsible on properly handling this update in a transaction.
+
+    # Not asynchronous because of #343; may be async if #326 allows it, but when
+    # recalculating a process it MUST be synchronous to the process' local and
+    # remote (if any) servers, so the TOPRecalcadoEvent is fully aware of both
+    # allocs. See #326 for context & to understand how async may be used here.
+    # hespawn(fn -> handle_checkpoint(processes_to_update) end)
+    handle_checkpoint(processes_to_update)
 
     # Returns a list of all processes the new server has (excluding completed
     # ones). The processes in this list are updated with the new `allocation`,

--- a/lib/process/model/process.ex
+++ b/lib/process/model/process.ex
@@ -13,6 +13,7 @@ defmodule Helix.Process.Model.Process do
   use HELL.ID, field: :process_id, meta: [0x0021]
 
   import Ecto.Changeset
+  import HELL.Macros
 
   alias Ecto.Changeset
   alias HELL.Constant
@@ -209,7 +210,7 @@ defmodule Helix.Process.Model.Process do
 
   @type time_left :: float
 
-  @type resource :: :cpu | :ram | :dlk | :ulk
+  @type resource :: Process.Resources.resource
 
   @type dynamic :: [resource]
 
@@ -329,6 +330,11 @@ defmodule Helix.Process.Model.Process do
     # Estimated time left for completion of the process. Seconds.
     field :time_left, :float,
       virtual: true
+
+    # Estimated progress percentage (resources processed / total objective)
+    field :percentage, :float,
+      virtual: true,
+      default: 0.0
 
     # Estimated completion date for the process.
     field :completion_date, :utc_datetime,
@@ -450,7 +456,9 @@ defmodule Helix.Process.Model.Process do
   @spec estimate_duration(t) ::
     t
   defp estimate_duration(process = %Process{}) do
-    {_, time_left} = TOP.Scheduler.estimate_completion(process)
+    {simulated_process, time_left} = TOP.Scheduler.estimate_completion(process)
+
+    percentage = estimate_percentage(simulated_process)
 
     completion_date =
       if time_left == :infinity do
@@ -472,6 +480,47 @@ defmodule Helix.Process.Model.Process do
     process
     |> Map.replace(:completion_date, completion_date)
     |> Map.replace(:time_left, time_left)
+    |> Map.replace(:percentage, percentage)
+  end
+
+  docp """
+  First line divides the total objective by the amount processed. This is pretty
+  much all we need to estimate the percentage.... HOWEVER, we need to ignore
+  resources that are not used, and the remainder (pun intended) of this function
+  is meant to filter out unwanted data. Plus, in case there are multiple
+  resources allocated, it chooses the one that have the least progress so far.
+  """
+  defp estimate_percentage(process = %Process{}) do
+    elapsed_percentage =
+      Process.Resources.div(process.processed, process.objective)
+
+    # Returns all resources that have some objective. Filters out resources that
+    # are not required in order to complete the process
+    objectives =
+      process.objective
+      |> Process.Resources.map(&(&1 > 0))
+      |> Enum.reject(fn {_res, val} -> val == false || val == %{} end)
+      |> Enum.reduce([], fn {res, _}, acc -> acc ++ [res] end)
+
+    # For each resource that is part of the objective, get the corresponding
+    # div result (first line of this function). If the result is higher than 0,
+    # it means the `processed` is empty and the `objective` got merged during
+    # the division. This is actually a bug, but one we've chosen to live with.
+    progress =
+      objectives
+      |> Enum.reduce([], fn res, acc ->
+        # Ensures we are returning the actual progress; NOT the merged objective
+        filter_merged = fn acc, v -> (v == 0.0 || v > 1) && 0.0 || v end
+
+        elapsed =
+          Process.Resources.call(
+            res, elapsed_percentage[res], :reduce, [0, filter_merged]
+          )
+
+        acc ++ [elapsed]
+      end)
+      |> Enum.sort()
+      |> List.first()
   end
 
   @spec format_resources(t) ::

--- a/lib/process/model/process.ex
+++ b/lib/process/model/process.ex
@@ -506,21 +506,20 @@ defmodule Helix.Process.Model.Process do
     # div result (first line of this function). If the result is higher than 0,
     # it means the `processed` is empty and the `objective` got merged during
     # the division. This is actually a bug, but one we've chosen to live with.
-    progress =
-      objectives
-      |> Enum.reduce([], fn res, acc ->
-        # Ensures we are returning the actual progress; NOT the merged objective
-        filter_merged = fn acc, v -> (v == 0.0 || v > 1) && 0.0 || v end
+    objectives
+    |> Enum.reduce([], fn res, acc ->
+      # Ensures we are returning the actual progress; NOT the merged objective
+      filter_merged = fn _, v -> (v == 0.0 || v > 1) && 0.0 || v end
 
-        elapsed =
-          Process.Resources.call(
-            res, elapsed_percentage[res], :reduce, [0, filter_merged]
-          )
+      elapsed =
+        Process.Resources.call(
+          res, elapsed_percentage[res], :reduce, [0, filter_merged]
+        )
 
-        acc ++ [elapsed]
-      end)
-      |> Enum.sort()
-      |> List.first()
+      acc ++ [elapsed]
+    end)
+    |> Enum.sort()
+    |> List.first()
   end
 
   @spec format_resources(t) ::

--- a/lib/process/model/process/resources.ex
+++ b/lib/process/model/process/resources.ex
@@ -27,6 +27,8 @@ resources Helix.Process.Model.Process.Resources do
       ulk: %{Network.id => type}
     }
 
+  @type resource :: :ram | :cpu | :dlk | :ulk
+
   resource RAM,
     behaviour: Behaviour.Default
 

--- a/lib/process/model/top/scheduler.ex
+++ b/lib/process/model/top/scheduler.ex
@@ -171,6 +171,8 @@ defmodule Helix.Process.Model.TOP.Scheduler do
   `checkpoint/1` we update the Process' `last_checkpoint_time`. Everything that
   happened *before* the `last_checkpoint_time` is already saved on `processed`.
   """
+  def checkpoint(%{next_allocation: nil, local?: _}),
+    do: false
   def checkpoint(%{l_reserved: alloc, next_allocation: alloc, local?: true}),
     do: false
   def checkpoint(%{r_reserved: alloc, next_allocation: alloc, local?: false}),

--- a/lib/process/model/top/scheduler.ex
+++ b/lib/process/model/top/scheduler.ex
@@ -261,7 +261,7 @@ defmodule Helix.Process.Model.TOP.Scheduler do
     # to complete the DLK objective, it will return 30s.
     estimated_seconds =
       work_left
-      |> Process.Resources.max()
+      |> Process.Resources.max_value()
       |> Kernel./(1000)  # From millisecond to second
       |> Float.round(2)
 

--- a/lib/process/public/view/helper.ex
+++ b/lib/process/public/view/helper.ex
@@ -138,7 +138,7 @@ defmodule Helix.Process.Public.View.Process.Helper do
       end
 
     %{
-      percentage: 0.5,
+      percentage: process.percentage,
       completion_date: completion_date,
       creation_date: ClientUtils.to_timestamp(process.creation_time)
     }

--- a/lib/process/public/view/helper.ex
+++ b/lib/process/public/view/helper.ex
@@ -9,6 +9,7 @@ defmodule Helix.Process.Public.View.Process.Helper do
   alias Helix.Cache.Query.Cache, as: CacheQuery
   alias Helix.Entity.Model.Entity
   alias Helix.Server.Model.Server
+  alias Helix.Server.Query.Server, as: ServerQuery
   alias Helix.Software.Model.File
   alias Helix.Software.Query.File, as: FileQuery
   alias Helix.Process.Model.Process
@@ -36,8 +37,13 @@ defmodule Helix.Process.Public.View.Process.Helper do
     connection_id = process.connection_id && to_string(process.connection_id)
     usage = build_usage(process)
 
-    partial = %{
-      origin_id: to_string(process.gateway_id),
+    # OPTIMIZE: Possibly cache `origin_ip` and `target_ip` on the Process.t
+    # It's used on several other places and must be queried every time it's
+    # displayed.
+    origin_ip = ServerQuery.get_ip(process.gateway_id, process.network_id)
+
+    full = %{
+      origin_ip: origin_ip,
       priority: process.priority,
       usage: usage,
       connection_id: connection_id,
@@ -45,7 +51,7 @@ defmodule Helix.Process.Public.View.Process.Helper do
 
     common = default_process_common(process, :full)
 
-    Map.merge(common, %{access: partial})
+    Map.merge(common, %{access: full})
   end
 
   @spec get_default_scope(term, Process.t, Server.id, Entity.id) ::

--- a/lib/process/public/view/process.ex
+++ b/lib/process/public/view/process.ex
@@ -7,6 +7,7 @@ defmodule Helix.Process.Public.View.Process do
 
   alias HELL.HETypes
   alias Helix.Entity.Model.Entity
+  alias Helix.Network.Model.Network
   alias Helix.Server.Model.Server
   alias Helix.Process.Model.Process
   alias Helix.Process.Public.View.ProcessViewable
@@ -32,7 +33,7 @@ defmodule Helix.Process.Public.View.Process do
 
   @typep full_access ::
     %{
-      origin_id: String.t,
+      origin_ip: Network.ip,
       priority: 0..5,
       usage: resources,
       connection_id: String.t | nil

--- a/lib/process/resources.ex
+++ b/lib/process/resources.ex
@@ -59,6 +59,14 @@ defmodule Helix.Process.Resources do
       def reduce(resource, initial, function),
         do: dispatch(:reduce, resource, [initial, function])
 
+      @spec call(resource, term, atom, [term]) ::
+        term
+      @doc """
+      Directly calls `function` on `resource`, passing `params` alongside it.
+      """
+      def call(resource, value, function, params),
+        do: call_resource(resource, function, [value] ++ params)
+
       @spec initial ::
         t
       @doc """
@@ -243,12 +251,12 @@ defmodule Helix.Process.Resources do
         end)
       end
 
-      @spec max(t) ::
+      @spec max_value(t) ::
         number
       @doc """
       Figure out which single resource has the greatest value.
       """
-      def max(resources) do
+      def max_value(resources) do
         resources
         |> reduce(0, fn acc, v -> max(acc, v) end)
 

--- a/lib/server/public/index.ex
+++ b/lib/server/public/index.ex
@@ -221,11 +221,9 @@ defmodule Helix.Server.Public.Index do
   - Resync client data with `bootstrap` request
   """
   def gateway(server = %Server{}, entity_id) do
-    name = "Server1"  # TODO
-
     index = %{
       password: server.password,
-      name: name
+      name: server.hostname
     }
 
     Map.merge(server_common(server, entity_id), index)

--- a/test/features/process/progress_test.exs
+++ b/test/features/process/progress_test.exs
@@ -1,0 +1,83 @@
+defmodule Helix.Test.Features.Process.Progress do
+
+  use Helix.Test.Case.Integration
+
+  alias Helix.Process.Action.TOP, as: TOPAction
+  alias Helix.Process.Query.Process, as: ProcessQuery
+  alias Helix.Software.Public.File, as: FilePublic
+
+  alias Helix.Test.Network.Setup, as: NetworkSetup
+  alias Helix.Test.Server.Helper, as: ServerHelper
+  alias Helix.Test.Server.Setup, as: ServerSetup
+  alias Helix.Test.Software.Helper, as: SoftwareHelper
+  alias Helix.Test.Software.Setup, as: SoftwareSetup
+
+  @moduletag :feature
+
+  @relay nil
+
+  describe "percentage" do
+
+    # Scenario: `server` will download a file from `target`. We'll pause and
+    # query the process again, after some time, to make sure it calculates the
+    # process estimated progress percentage.
+    test "percentage is updated as process progresses" do
+      {server, _} = ServerSetup.server()
+      {target, _} = ServerSetup.server()
+
+      res_server = %{dlk: 100, ulk: 100}
+      res_target = %{dlk: 100, ulk: 100}
+
+      ServerHelper.update_server_specs(server, res_server)
+      ServerHelper.update_server_specs(target, res_target)
+
+      storage = SoftwareHelper.get_storage(server)
+
+      {tunnel, _} =
+        NetworkSetup.tunnel(
+          gateway_id: server.server_id, destination_id: target.server_id
+        )
+
+      # File has size 100, and will be downloaded at rate 100/s. So it takes 1s
+      {dl_file, _} = SoftwareSetup.file(server_id: target.server_id, size: 100)
+
+      assert {:ok, %{process_id: download_id}} =
+        FilePublic.download(server, target, tunnel, storage, dl_file, @relay)
+
+      # We've just started the downloaded, so it ran ~0%
+      download0 = ProcessQuery.fetch(download_id)
+      assert_in_delta download0.percentage, 0, 0.07
+      assert_in_delta download0.time_left, 1.0, 0.07
+
+      # Sleep 100ms, which is about 10%
+      :timer.sleep(100)
+
+      # Yep, we are somewhere near 10%
+      download1 = ProcessQuery.fetch(download_id)
+      assert_in_delta download1.percentage, 0.1, 0.07
+      assert_in_delta download1.time_left, 0.9, 0.07
+
+      # Sleep another 100ms (+10%)
+      :timer.sleep(100)
+
+      # Percentage is at 20%
+      download2 = ProcessQuery.fetch(download_id)
+      assert_in_delta download2.percentage, 0.2, 0.07
+
+      # Now we'll tragically make increase the download time.
+      # The time_left will increase, but the percentage shouldn't change
+      ServerHelper.update_server_specs(server, %{dlk: 1})
+
+      # Run recalque so the new server specs are applied to the process
+      TOPAction.recalque(server.server_id)
+
+      download3 = ProcessQuery.fetch(download_id)
+
+      # Time left increase 100 fold
+      assert_in_delta download3.time_left, download2.time_left * 100, 1
+
+      # Percentage barely changed
+      assert_in_delta download3.percentage, download2.percentage, 0.01
+    end
+  end
+end

--- a/test/process/action/top_test.exs
+++ b/test/process/action/top_test.exs
@@ -97,8 +97,9 @@ defmodule Helix.Process.Action.TOPTest do
       # Let's recalque the TOP again. Theoretically, nothing should change.
       assert {:ok, [proc_recalque2], _} = TOPAction.recalque(gateway.server_id)
 
-      # Allocation is the same...
-      assert proc_recalque2.next_allocation == proc_recalque.next_allocation
+      # The new process has no `next_allocation`, meaning the allocation is
+      # exactly the same as to what was reserved before.
+      refute proc_recalque2.next_allocation
 
       # Now this is interesting. We'll detail this verification below because
       # it *is* important (and it *does* fixes a bug).

--- a/test/process/model/process_test.exs
+++ b/test/process/model/process_test.exs
@@ -223,7 +223,8 @@ defmodule Helix.Process.Model.ProcessTest do
           r_reserved: %{cpu: 30, ram: 30, ulk: %{}, dlk: %{"::" => 20}},
           r_dynamic: [:ulk],
           network_id: "::",
-          data: FakeFileTransfer.new()
+          data: FakeFileTransfer.new(),
+          processed: %{}
         )
 
       process = Process.format(proc)

--- a/test/process/public/index_test.exs
+++ b/test/process/public/index_test.exs
@@ -70,7 +70,7 @@ defmodule Helix.Process.Public.IndexTest do
 
       # Process3 is partial, i.e. I have limited information about it.
       # For instance, I don't know who started it
-      refute Map.has_key?(result_process3.access, :origin_id)
+      refute Map.has_key?(result_process3.access, :origin_ip)
 
       TOPHelper.top_stop(server.server_id)
     end

--- a/test/process/public/index_test.exs
+++ b/test/process/public/index_test.exs
@@ -51,7 +51,7 @@ defmodule Helix.Process.Public.IndexTest do
 
       # Result comes in binary format
       assert is_binary(result_process1.process_id)
-      assert is_binary(result_process1.access.origin_id)
+      assert is_binary(result_process1.access.origin_ip)
       assert is_binary(result_process1.target_ip)
       assert is_binary(result_process1.state)
       assert is_binary(result_process1.network_id)

--- a/test/server/public/index_test.exs
+++ b/test/server/public/index_test.exs
@@ -180,7 +180,7 @@ defmodule Helix.Server.Public.IndexTest do
 
       # ServerIndex info
       assert gateway.nips == server_nips
-      assert gateway.name
+      assert gateway.name == server.hostname
       assert gateway.password == server.password
 
       # Info retrieved from sub-Indexes

--- a/test/server/websocket/channel/server/topics/cracker_test.exs
+++ b/test/server/websocket/channel/server/topics/cracker_test.exs
@@ -47,7 +47,7 @@ defmodule Helix.Server.Websocket.Channel.Server.Topics.CrackerTest do
       # All required fields are there
       assert process_created_event.data.type == "cracker_bruteforce"
       assert process_created_event.data.file
-      assert process_created_event.data.access.origin_id
+      assert process_created_event.data.access.origin_ip
       assert process_created_event.data.access.priority
       assert process_created_event.data.access.usage
       assert process_created_event.data.network_id

--- a/test/support/process/helper/view.ex
+++ b/test/support/process/helper/view.ex
@@ -2,7 +2,7 @@ defmodule Helix.Test.Process.View.Helper do
 
   def pview_access_full do
     ~w/
-      origin_id
+      origin_ip
       priority
       usage
       connection_id


### PR DESCRIPTION
Depends on #338 

- Add percentage to Process (used by Client to display the TaskManager properly)
- Return `origin_ip` when a process is considered to be of "full access" type (previously it returned `origin_id`).
- Return the correct Server.hostname on ServerIndex
- Fix TOP plays Darude Sandstorm bug (#343)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/342)
<!-- Reviewable:end -->
