### PR TITLE
Add Story.Context

### DIFF
--- a/lib/story/action/context.ex
+++ b/lib/story/action/context.ex
@@ -1,0 +1,95 @@
+defmodule Helix.Story.Action.Context do
+
+  import HELL.Macros
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Story.Internal.Context, as: ContextInternal
+  alias Helix.Story.Model.Story
+
+  @typep key :: Story.Context.key
+
+  @spec create(Entity.idt) ::
+    {:ok, Story.Context.t}
+    | {:error, Story.Context.changeset}
+  @doc """
+  Creates the Story.Context entry for Entity. Initial context is empty (%{}).
+  """
+  def create(entity = %Entity{}),
+    do: create(entity.entity_id)
+  def create(entity_id = %Entity.ID{}),
+    do: ContextInternal.create(entity_id)
+
+  @spec save(Entity.idt, key, key | [key], Story.Context.value) ::
+    {:ok, Story.Context.t}
+    | {:error, :path_exists}
+  @doc """
+  Appends a new entry to the entity's context. The given path may be nested.
+
+  Save is an explicit operation and as such the path MUST NOT exist.
+
+  # Example:
+
+  Calling `save(entity, :foo, [:bar, :baz], 10)` will add the entry
+  `%{foo: %{bar: %{baz: 10}}}`
+  """
+  def save(entity = %Entity{}, field, subfield, value),
+    do: save(entity.entity_id, field, subfield, value)
+  def save(entity_id, field, subfield, value) when not is_list(subfield),
+    do: save(entity_id, field, [subfield], value)
+  def save(entity_id, field, subfields, value) do
+    path = [field] ++ subfields
+    entry = mapify_entry(path, value)
+
+    ContextInternal.save(entity_id, entry, path)
+  end
+
+  @spec update(Entity.idt, key, key | [key], Story.Context.value) ::
+    {:ok, Story.Context.t}
+    | {:error, :path_exists}
+
+  @doc """
+  Updates an existing entry on the entity's context. Path may be nested.
+
+  Update is an explicit operation and as such the path MUST ALREADY exist.
+
+  # Example:
+
+  Calling `update(entity, :foo, [:bar, :baz], 10)` will update the entry on
+  path [:foo, :bar, :baz] to `%{foo: %{bar: %{baz: 10}}}`
+  """
+  def update(entity = %Entity{}, field, subfield, value),
+    do: update(entity.entity_id, field, subfield, value)
+  def update(entity_id, field, subfield, value) when not is_list(subfield),
+    do: update(entity_id, field, [subfield], value)
+  def update(entity_id, field, subfields, value) do
+    path = [field] ++ subfields
+    entry = mapify_entry(path, value)
+
+    ContextInternal.update(entity_id, entry, path)
+  end
+
+  defdelegate delete(context),
+    to: ContextInternal
+
+  @spec mapify_entry([atom], term) ::
+    map
+  docp """
+  Maps the given keys (list of atoms) to a nested map with value `value`.
+
+  # Example:
+
+  > mapify_entry([:foo, :bar], 1)
+  > %{foo: %{bar: 2}}
+  """
+  defp mapify_entry(path, value) do
+    Enum.reduce(path, {%{}, []}, fn key, {map, iterated} ->
+      relative_key = iterated ++ [key]
+
+      if relative_key == path do
+        put_in(map, relative_key, value)
+      else
+        {put_in(map, relative_key, %{}), relative_key}
+      end
+    end)
+  end
+end

--- a/lib/story/action/context.ex
+++ b/lib/story/action/context.ex
@@ -36,6 +36,8 @@ defmodule Helix.Story.Action.Context do
     do: save(entity.entity_id, field, subfield, value)
   def save(entity_id, field, subfield, value) when not is_list(subfield),
     do: save(entity_id, field, [subfield], value)
+  def save(entity_id, field, subfields, id = %_{id: _}),
+    do: save(entity_id, field, subfields, Story.Context.store_id(id))
   def save(entity_id, field, subfields, value) do
     path = [field] ++ subfields
     entry = mapify_entry(path, value)
@@ -46,7 +48,6 @@ defmodule Helix.Story.Action.Context do
   @spec update(Entity.idt, key, key | [key], Story.Context.value) ::
     {:ok, Story.Context.t}
     | {:error, :path_exists}
-
   @doc """
   Updates an existing entry on the entity's context. Path may be nested.
 
@@ -61,6 +62,8 @@ defmodule Helix.Story.Action.Context do
     do: update(entity.entity_id, field, subfield, value)
   def update(entity_id, field, subfield, value) when not is_list(subfield),
     do: update(entity_id, field, [subfield], value)
+  def update(entity_id, field, subfields, id = %_{id: _}),
+    do: update(entity_id, field, subfields, Story.Context.store_id(id))
   def update(entity_id, field, subfields, value) do
     path = [field] ++ subfields
     entry = mapify_entry(path, value)
@@ -68,11 +71,14 @@ defmodule Helix.Story.Action.Context do
     ContextInternal.update(entity_id, entry, path)
   end
 
+  @doc """
+  Deletes the Story.Context entry
+  """
   defdelegate delete(context),
     to: ContextInternal
 
-  @spec mapify_entry([atom], term) ::
-    map
+  @spec mapify_entry(Story.Context.path, Story.Context.value) ::
+    Story.Context.context
   docp """
   Maps the given keys (list of atoms) to a nested map with value `value`.
 

--- a/lib/story/action/flow/context.ex
+++ b/lib/story/action/flow/context.ex
@@ -1,0 +1,27 @@
+defmodule Helix.Story.Action.Flow.Context do
+
+  import HELF.Flow
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Story.Action.Context, as: ContextAction
+  alias Helix.Story.Model.Story
+
+  @spec setup(Entity.t) ::
+    {:ok, Story.Context.t}
+  @doc """
+  Creates the Story.Context entry for the given Entity.
+
+  Must be called during the preparation/setup of the Storyline, as steps will
+  assume the Story.Context entry already exists.
+  """
+  def setup(entity) do
+    flowing do
+      with \
+        {:ok, context} <- ContextAction.create(entity),
+        on_fail(fn -> ContextAction.delete(context) end)
+      do
+        {:ok, context}
+      end
+    end
+  end
+end

--- a/lib/story/action/flow/story.ex
+++ b/lib/story/action/flow/story.ex
@@ -4,6 +4,7 @@ defmodule Helix.Story.Action.Flow.Story do
 
   alias Helix.Event
   alias Helix.Entity.Model.Entity
+  alias Helix.Story.Action.Flow.Context, as: ContextFlow
   alias Helix.Story.Action.Story, as: StoryAction
   alias Helix.Story.Model.Step
   alias Helix.Story.Model.Steppable
@@ -15,6 +16,9 @@ defmodule Helix.Story.Action.Flow.Story do
   Effectively "starts" the storyline for the given `entity`, "proceeding" it to
   the first step.
 
+  Before doing so, however, it creates the Story.Context for that entity, which
+  will be used for medium- and long-term storage of storyline data.
+
   It requires Story.Manager, as it will be used to determine the entity's story
   network/server, which may be used by the first step.
   """
@@ -23,7 +27,8 @@ defmodule Helix.Story.Action.Flow.Story do
 
     flowing do
       with \
-        {:ok, story_step} = StoryAction.proceed_step(first_step),
+        {:ok, _} <- ContextFlow.setup(entity),
+        {:ok, story_step} <- StoryAction.proceed_step(first_step),
         {:ok, _, events} <- Steppable.setup(first_step, nil),
         on_success(fn -> Event.emit(events, from: relay) end)
       do

--- a/lib/story/event/handler/manager.ex
+++ b/lib/story/event/handler/manager.ex
@@ -33,7 +33,6 @@ defmodule Helix.Story.Event.Handler.Manager do
 
         # Start the story (creates the first step)
         {:ok, _} <- StoryFlow.start_story(entity, manager, event)
-
       do
         {:ok, server, motherboard}
       end

--- a/lib/story/internal/context.ex
+++ b/lib/story/internal/context.ex
@@ -68,7 +68,7 @@ defmodule Helix.Story.Internal.Context do
 
         {:ok, new_story_context} = update_entry(cur_story_context, entry)
       do
-        new_story_context
+        Story.Context.format(new_story_context)
       else
         _ ->
           Repo.rollback(:path_exists)
@@ -96,7 +96,7 @@ defmodule Helix.Story.Internal.Context do
 
         {:ok, new_story_context} = update_entry(cur_story_context, entry)
       do
-        new_story_context
+        Story.Context.format(new_story_context)
       else
         _ ->
           Repo.rollback(:path_not_found)
@@ -113,6 +113,9 @@ defmodule Helix.Story.Internal.Context do
     :ok
   end
 
+  @spec update_entry(Story.Context.t, Story.Context.context) ::
+    {:ok, Story.Context.t}
+    | {:error, Story.Context.changeset}
   defp update_entry(context, entry) do
     context
     |> Story.Context.update(entry)

--- a/lib/story/internal/context.ex
+++ b/lib/story/internal/context.ex
@@ -1,0 +1,121 @@
+defmodule Helix.Story.Internal.Context do
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Story.Model.Story
+  alias Helix.Story.Repo
+
+  @spec fetch(Entity.id) ::
+    Story.Context.t
+    | nil
+  def fetch(entity_id) do
+    result =
+      entity_id
+      |> Story.Context.Query.by_entity()
+      |> Repo.one()
+
+    with %{} <- result do
+      Story.Context.format(result)
+    end
+  end
+
+  @spec fetch_for_update(Entity.id) ::
+    Story.Context.t
+    | no_return
+  @doc """
+  Fetches a row with the intent of updating it.
+
+  The row MUST exist, otherwise an exception is raised.
+  """
+  def fetch_for_update(entity_id) do
+    unless Repo.in_transaction?(),
+      do: raise "Transaction required in order to acquire lock"
+
+    entity_id
+    |> Story.Context.Query.by_entity()
+    |> Story.Context.Query.lock_for_update()
+    |> Repo.one!()
+    |> Story.Context.format()
+  end
+
+  @spec create(Entity.id) ::
+    {:ok, Story.Context.t}
+    | {:error, Story.Context.changeset}
+  def create(entity_id) do
+    %{entity_id: entity_id}
+    |> Story.Context.create()
+    |> Repo.insert()
+  end
+
+  @spec save(Entity.id, map, Story.Context.path) ::
+    {:ok, Story.Context.t}
+    | {:error, :path_exists}
+    | no_return
+  @doc """
+  Adds `entry` to the context that belongs to `entity_id`.
+
+  Notice that `save` is supposed to add a value for the first time! As such, an
+  error will raise if the requested key is already set. If you want to update an
+  existing key, use `update/3` instead.
+  """
+  def save(entity_id, entry, path) do
+    Repo.transaction fn ->
+      cur_story_context = fetch_for_update(entity_id)
+
+      with \
+        nil <- get_in(cur_story_context.context, path),
+        # /\ Make sure the value we are inserting isn't already saved
+        # TODO: this verification WILL fail if the value within `path` is nil
+
+        {:ok, new_story_context} = update_entry(cur_story_context, entry)
+      do
+        new_story_context
+      else
+        _ ->
+          Repo.rollback(:path_exists)
+      end
+    end
+  end
+
+  @spec update(Entity.id, map, Story.Context.path) ::
+    {:ok, Story.Context.t}
+    | {:error, :path_not_found}
+    | no_return
+  @doc """
+  Adds `entry` within the given `path`.
+
+  Notice that `update` explicitly requires that the given path already exists!
+  Bad things happen for those who defy this rule.
+  """
+  def update(entity_id, entry, path) do
+    Repo.transaction fn ->
+      cur_story_context = fetch_for_update(entity_id)
+
+      with \
+        true <- not is_nil(get_in(cur_story_context.context, path)),
+        # /\ Make sure the value we are updating ALREADY exists
+
+        {:ok, new_story_context} = update_entry(cur_story_context, entry)
+      do
+        new_story_context
+      else
+        _ ->
+          Repo.rollback(:path_not_found)
+      end
+    end
+  end
+
+  @spec delete(Story.Context.t) ::
+    :ok
+  def delete(context = %Story.Context{}) do
+    context
+    |> Repo.delete()
+
+    :ok
+  end
+
+  defp update_entry(context, entry) do
+    context
+    |> Story.Context.update(entry)
+    |> Repo.update()
+  end
+end

--- a/lib/story/mission/tutorial/steps.ex
+++ b/lib/story/mission/tutorial/steps.ex
@@ -27,9 +27,10 @@ defmodule Helix.Story.Mission.Tutorial do
 
   step DownloadCrackerPublicFtp do
 
-    alias Helix.Software.Model.File
     alias Helix.Server.Model.Server
     alias Helix.Server.Query.Server, as: ServerQuery
+    alias Helix.Software.Model.File
+    alias Helix.Story.Action.Context, as: ContextAction
 
     alias Helix.Software.Event.File.Downloaded, as: FileDownloadedEvent
 
@@ -48,10 +49,10 @@ defmodule Helix.Story.Mission.Tutorial do
       send: "give_more_info"
 
     def setup(step, _) do
-      {:ok, server, %{entity: _e}} = StoryMake.char(step.manager.network_id)
+      {:ok, server, %{entity: entity}} = StoryMake.char(step.manager.network_id)
 
-      # ContextAction.save(@contact, :server_id, server)
-      # ContextAction.save(@contact, :entity_id, entity)
+      ContextAction.save(step.entity_id, @contact, :server_id, server.server_id)
+      ContextAction.save(step.entity_id, @contact, :entity_id, entity.entity_id)
 
       # Create the Cracker the player is supposed to download
       cracker = MakeFile.cracker!(server, %{bruteforce: 10, overflow: 10})

--- a/lib/story/model/story/context.ex
+++ b/lib/story/model/story/context.ex
@@ -1,0 +1,82 @@
+defmodule Helix.Story.Model.Story.Context do
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import HELL.Ecto.Macros
+
+  alias Ecto.Changeset
+  alias HELL.MapUtils
+  alias Helix.Entity.Model.Entity
+  alias Helix.Story.Model.Story
+
+  @type t ::
+    %__MODULE__{
+      entity_id: Entity.id,
+      context: context
+    }
+
+  @type value :: term
+  @type context :: map
+  @type path :: [key]
+  @type key :: atom
+
+  @type changeset :: %Changeset{data: %__MODULE__{}}
+
+  @type creation_params :: %{entity_id: Entity.id}
+
+  @creation_fields [:entity_id]
+  @required_fields [:entity_id]
+
+  @primary_key false
+  schema "story_contexts" do
+    field :entity_id, Entity.ID,
+      primary_key: true
+
+    field :context, :map,
+      default: %{}
+  end
+
+  def create(params) do
+    %__MODULE__{}
+    |> cast(params, @creation_fields)
+    |> validate_required(@required_fields)
+  end
+
+  @doc """
+  Merges the current existing context with the new entry requested by the user.
+
+  If a conflict happens, the new entry takes precedence (overwrites the old one)
+  """
+  def merge_context(context, entry),
+    do: MapUtils.naive_deep_merge(context, entry, fn _a, b -> b end)
+
+  def update(story_context = %Story.Context{}, entry) do
+    new_context = merge_context(story_context.context, entry)
+
+    story_context
+    |> change()
+    |> put_change(:context, new_context)
+  end
+
+  def format(story_context = %Story.Context{}) do
+    formatted_context = MapUtils.atomize_keys(story_context.context)
+
+    %{story_context| context: formatted_context}
+  end
+
+  query do
+
+    alias Helix.Story.Model.Story
+
+    @spec by_entity(Queryable.t, Entity.id) ::
+      Queryable.t
+    def by_entity(query \\ Story.Context, entity_id),
+      do: where(query, [sc], sc.entity_id == ^entity_id)
+
+    @spec lock_for_update(Queryable.t) ::
+      Queryable.t
+    def lock_for_update(query),
+      do: lock(query, "FOR UPDATE")
+  end
+end

--- a/lib/story/model/story/context.ex
+++ b/lib/story/model/story/context.ex
@@ -1,4 +1,11 @@
 defmodule Helix.Story.Model.Story.Context do
+  @moduledoc """
+  Story.Context is a medium- to long-term storage of arbitrary Storyline data.
+
+  Not to confuse with Story.Manager, which is used for structured data used
+  throughout the entire Storyline. Short-lived data that span only one or a few
+  steps should be persisted on Story.Step meta.
+  """
 
   use Ecto.Schema
 
@@ -18,12 +25,19 @@ defmodule Helix.Story.Model.Story.Context do
 
   @type value :: term
   @type context :: map
+  @type entry :: context
   @type path :: [key]
   @type key :: atom
 
   @type changeset :: %Changeset{data: %__MODULE__{}}
 
   @type creation_params :: %{entity_id: Entity.id}
+
+  @typep context_id ::
+    %{
+      __id__: String.t,
+      __root__: String.t
+    }
 
   @creation_fields [:entity_id]
   @required_fields [:entity_id]
@@ -37,20 +51,16 @@ defmodule Helix.Story.Model.Story.Context do
       default: %{}
   end
 
+  @spec create(creation_params) ::
+    changeset
   def create(params) do
     %__MODULE__{}
     |> cast(params, @creation_fields)
     |> validate_required(@required_fields)
   end
 
-  @doc """
-  Merges the current existing context with the new entry requested by the user.
-
-  If a conflict happens, the new entry takes precedence (overwrites the old one)
-  """
-  def merge_context(context, entry),
-    do: MapUtils.naive_deep_merge(context, entry, fn _a, b -> b end)
-
+  @spec update(t, entry) ::
+    changeset
   def update(story_context = %Story.Context{}, entry) do
     new_context = merge_context(story_context.context, entry)
 
@@ -59,11 +69,65 @@ defmodule Helix.Story.Model.Story.Context do
     |> put_change(:context, new_context)
   end
 
+  @spec merge_context(context, entry) ::
+    context
+  @doc """
+  Merges the current existing context with the new entry requested by the user.
+
+  If a conflict happens, the new entry takes precedence (overwrites the old one)
+  """
+  def merge_context(context, entry),
+    do: MapUtils.naive_deep_merge(context, entry, fn _a, b -> b end)
+
+  @spec format(t) ::
+    t
+  @doc """
+  Formats the Story.Context entry fetched from the DB (JSONB) to internal Helix
+  format. This includes:
+
+  - Atomizing map keys (which are retrieved from the DB as strings)
+  - Converting Helix IDs from binary to the corresponding ID struct.
+  """
   def format(story_context = %Story.Context{}) do
-    formatted_context = MapUtils.atomize_keys(story_context.context)
+    formatted_context =
+      story_context.context
+      |> MapUtils.atomize_keys()
+      |> format_ids()
 
     %{story_context| context: formatted_context}
   end
+
+  @spec store_id(struct) ::
+    context_id
+  @doc """
+  Maps an Helix ID to a custom format that will be handled by the Story.Context,
+  at the `format/1` step. This allows users of the Context API to transparently
+  save and fetch Helix IDs.
+  """
+  def store_id(id = %_{id: _, root: module}) do
+    %{
+      __id__: to_string(id),
+      __root__: to_string(module)
+    }
+  end
+
+  @spec format_ids(term) ::
+    context
+  defp format_ids(%{__id__: id, __root__: root}) do
+    root
+    |> Kernel.<>(".ID")
+    |> String.to_atom()
+    |> apply(:cast!, [id])
+  end
+  defp format_ids(id = %_{id: _, root: _}),
+    do: id
+  defp format_ids(context = %{}) do
+    context
+    |> Enum.map(fn {k, v} -> {k, format_ids(v)} end)
+    |> Enum.into(%{})
+  end
+  defp format_ids(not_id),
+    do: not_id
 
   query do
 

--- a/lib/story/model/story/email.ex
+++ b/lib/story/model/story/email.ex
@@ -96,7 +96,7 @@ defmodule Helix.Story.Model.Story.Email do
     formatted_emails =
       entry.emails
       |> Enum.map(&format_email/1)
-      |> Enum.sort(&(&2.timestamp >= &1.timestamp))
+      |> Enum.sort(&(DateTime.compare(&2.timestamp, &1.timestamp) == :gt))
 
     %{entry| emails: formatted_emails}
   end

--- a/lib/story/query/context.ex
+++ b/lib/story/query/context.ex
@@ -1,0 +1,43 @@
+defmodule Helix.Story.Query.Context do
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Story.Internal.Context, as: ContextInternal
+  alias Helix.Story.Model.Story
+
+  @typep key :: Story.Context.key
+
+  defdelegate fetch(entity_id),
+    to: ContextInternal
+
+  @spec get(Entity.idt | Story.Context.t, key) ::
+    Story.Context.context
+    | nil
+  def get(entity = %Entity{}, root),
+    do: get(entity.entity_id, root)
+  def get(entity_id = %Entity.ID{}, root) do
+    with story_context = %{} <- fetch(entity_id) do
+      get(story_context, root)
+    end
+  end
+  def get(%Story.Context{context: context}, root),
+    do: Map.get(context, root)
+
+  @spec get(Entity.idt | Story.Context.t, key, key | [key]) ::
+    Story.Context.context
+    | Story.Context.value
+    | nil
+  def get(entity = %Entity{}, root, fields),
+    do: get(entity.entity_id, root, fields)
+  def get(entity_id = %Entity.ID{}, root, fields) do
+    with story_context = %{} <- fetch(entity_id) do
+      get(story_context, root, fields)
+    end
+  end
+
+  def get(story_context = %Story.Context{}, root, key) when not is_list(key),
+    do: get(story_context, root, [key])
+  def get(%Story.Context{context: context}, root, keys) do
+    path = [root] ++ keys
+    get_in(context, path)
+  end
+end

--- a/lib/universe/bank/model/bank_transfer.ex
+++ b/lib/universe/bank/model/bank_transfer.ex
@@ -4,6 +4,7 @@ defmodule Helix.Universe.Bank.Model.BankTransfer do
   use HELL.ID, field: :transfer_id, meta: [0x0040]
 
   import Ecto.Changeset
+  import HELL.Ecto.Macros
 
   alias Helix.Account.Model.Account
   alias Helix.Server.Model.Server
@@ -83,18 +84,17 @@ defmodule Helix.Universe.Bank.Model.BankTransfer do
   defp add_time_information(changeset),
     do: put_change(changeset, :started_time, DateTime.utc_now())
 
-  defmodule Query do
+  query do
 
-    import Ecto.Query, only: [where: 3, lock: 2]
-
-    alias Helix.Account.Model.Account
     alias Helix.Universe.Bank.Model.BankTransfer
 
-    @spec by_id(Ecto.Queryable.t, BankTransfer.id) ::
-      Ecto.Queryable.t
+    @spec by_id(Queryable.t, BankTransfer.id) ::
+      Queryable.t
     def by_id(query \\ BankTransfer, transfer),
       do: where(query, [t], t.transfer_id == ^transfer)
 
+    @spec lock_for_update(Queryable.t) ::
+      Queryable.t
     def lock_for_update(query),
       do: lock(query, "FOR UPDATE")
   end

--- a/priv/repo/story/migrations/20180104071855_add_story_context.exs
+++ b/priv/repo/story/migrations/20180104071855_add_story_context.exs
@@ -1,0 +1,11 @@
+defmodule Helix.Story.Repo.Migrations.AddStoryContext do
+  use Ecto.Migration
+
+  def change do
+    create table(:story_contexts, primary_key: false) do
+      add :entity_id, :inet, primary_key: true
+
+      add :context, :map
+    end
+  end
+end

--- a/test/features/process/progress_test.exs
+++ b/test/features/process/progress_test.exs
@@ -46,23 +46,26 @@ defmodule Helix.Test.Features.Process.Progress do
 
       # We've just started the downloaded, so it ran ~0%
       download0 = ProcessQuery.fetch(download_id)
-      assert_in_delta download0.percentage, 0, 0.08
-      assert_in_delta download0.time_left, 1.0, 0.08
+      assert_in_delta download0.percentage, 0, 0.1
+      assert_in_delta download0.time_left, 1.0, 0.1
 
       # Sleep 100ms, which is about 10%
       :timer.sleep(100)
 
       # Yep, we are somewhere near 10%
       download1 = ProcessQuery.fetch(download_id)
-      assert_in_delta download1.percentage, 0.1, 0.08
-      assert_in_delta download1.time_left, 0.9, 0.08
+      assert_in_delta download1.percentage, 0.1, 0.1
+      assert_in_delta download1.time_left, 0.9, 0.1
+
+      # NOTE: these insanely high delta is due to extremely slow build systems
+      # (Travis I'm looking at you).
 
       # Sleep another 100ms (+10%)
       :timer.sleep(100)
 
       # Percentage is at 20%
       download2 = ProcessQuery.fetch(download_id)
-      assert_in_delta download2.percentage, 0.2, 0.08
+      assert_in_delta download2.percentage, 0.2, 0.1
 
       # Now we'll tragically make increase the download time.
       # The time_left will increase, but the percentage shouldn't change
@@ -73,11 +76,11 @@ defmodule Helix.Test.Features.Process.Progress do
 
       download3 = ProcessQuery.fetch(download_id)
 
-      # Time left increase 100 fold
-      assert_in_delta download3.time_left, download2.time_left * 100, 1
+      # Time left increase 100 fold (DLK went from 100 to 1)
+      assert_in_delta download3.time_left, download2.time_left * 100, 2
 
       # Percentage barely changed
-      assert_in_delta download3.percentage, download2.percentage, 0.01
+      assert_in_delta download3.percentage, download2.percentage, 0.02
     end
   end
 end

--- a/test/features/storyline/flow_test.exs
+++ b/test/features/storyline/flow_test.exs
@@ -40,7 +40,7 @@ defmodule Helix.Test.Features.Storyline.Flow do
       ref = push account_socket, "email.reply", params
       assert_reply ref, :ok, _, timeout(:slow)
 
-      # Now we've proceeded to the next step
+      # Now we've proceeded to the next step.
       [story_step_proceeded] = wait_events [:story_step_proceeded]
 
       assert_transition story_step_proceeded, "setup_pc", "download_cracker"

--- a/test/story/action/context_test.exs
+++ b/test/story/action/context_test.exs
@@ -2,7 +2,9 @@ defmodule Helix.Story.Action.ContextTest do
 
   use Helix.Test.Case.Integration
 
+  alias Helix.Server.Model.Server
   alias Helix.Story.Action.Context, as: ContextAction
+  alias Helix.Story.Query.Context, as: ContextQuery
 
   alias Helix.Test.Story.Setup, as: StorySetup
 
@@ -27,6 +29,20 @@ defmodule Helix.Story.Action.ContextTest do
       assert story_context.context == %{foo: %{bar: %{baz: %{inga: 42}}}}
     end
 
+    test "handles Helix ID transparently" do
+      {%{entity_id: entity_id}, _} = StorySetup.Context.context()
+
+      server_id = Server.ID.generate()
+      assert {:ok, story_context} =
+        ContextAction.save(entity_id, :foo, [:id], server_id)
+
+      assert story_context.context.foo.id == server_id
+
+      # Let's query it to make sure it returns the same result
+      db_context = ContextQuery.fetch(entity_id)
+      assert db_context.context.foo.id == server_id
+    end
+
     test "refuses to save an entry that already exists" do
       cur_context = %{foo: %{bar: 1}}
       {story_context, _} = StorySetup.Context.context(context: cur_context)
@@ -35,6 +51,58 @@ defmodule Helix.Story.Action.ContextTest do
       assert {:error, reason} =
         ContextAction.save(story_context.entity_id, :foo, :bar, 2)
       assert reason == :path_exists
+    end
+  end
+
+  describe "update/4" do
+    test "updates an entry" do
+      cur_context = %{foo: %{bar: 1}}
+      {story_context, _} = StorySetup.Context.context(context: cur_context)
+
+      assert {:ok, new_story_context} =
+        ContextAction.update(story_context.entity_id, :foo, :bar, 2)
+
+      refute story_context == new_story_context
+      assert new_story_context.context.foo.bar == 2
+    end
+
+    test "accepts nested subfields" do
+      cur_context = %{foo: %{bar: %{baz: 1}}}
+      {story_context, _} = StorySetup.Context.context(context: cur_context)
+
+      assert {:ok, new_story_context} =
+        ContextAction.update(story_context.entity_id, :foo, [:bar, :baz], 2)
+
+      assert new_story_context.context.foo.bar.baz == 2
+    end
+
+    test "handles Helix ID transparently" do
+      {%{entity_id: entity_id}, _} = StorySetup.Context.context()
+
+      id_1 = Server.ID.generate()
+      id_2 = Server.ID.generate()
+
+      # Let's add a Server.ID to `foo.bar`
+      assert {:ok, _} = ContextAction.save(entity_id, :foo, :bar, id_1)
+
+      # Now let's update it to another ID
+      assert {:ok, story_context} =
+        ContextAction.update(entity_id, :foo, :bar, id_2)
+
+      assert story_context.context.foo.bar == id_2
+
+      # Fetching from DB also returns the correct ID
+      db_context = ContextQuery.fetch(entity_id)
+      assert db_context.context.foo.bar == id_2
+    end
+
+    test "refuses to update an entry that does not exist" do
+      {story_context, _} = StorySetup.Context.context()
+      assert Enum.empty?(story_context.context)
+
+      assert {:error, reason} =
+        ContextAction.update(story_context.entity_id, :foo, :bar, 1)
+      assert reason == :path_not_found
     end
   end
 end

--- a/test/story/action/context_test.exs
+++ b/test/story/action/context_test.exs
@@ -1,0 +1,40 @@
+defmodule Helix.Story.Action.ContextTest do
+
+  use Helix.Test.Case.Integration
+
+  alias Helix.Story.Action.Context, as: ContextAction
+
+  alias Helix.Test.Story.Setup, as: StorySetup
+
+  describe "save/4" do
+    test "saves the value within the given path" do
+      {%{entity_id: entity_id}, _} = StorySetup.Context.context()
+
+      assert {:ok, story_context} =
+        ContextAction.save(entity_id, :foo, :bar, "baridade")
+
+      # Added the context as expected
+      expected_context = %{foo: %{bar: "baridade"}}
+      assert story_context.context == expected_context
+    end
+
+    test "accepts nested subfields" do
+      {%{entity_id: entity_id}, _} = StorySetup.Context.context()
+
+      assert {:ok, story_context} =
+        ContextAction.save(entity_id, :foo, [:bar, :baz, :inga], 42)
+
+      assert story_context.context == %{foo: %{bar: %{baz: %{inga: 42}}}}
+    end
+
+    test "refuses to save an entry that already exists" do
+      cur_context = %{foo: %{bar: 1}}
+      {story_context, _} = StorySetup.Context.context(context: cur_context)
+
+      # We are trying to set `foo.bar = 2`, but it's already set as 1!
+      assert {:error, reason} =
+        ContextAction.save(story_context.entity_id, :foo, :bar, 2)
+      assert reason == :path_exists
+    end
+  end
+end

--- a/test/story/event/handler/manager_test.exs
+++ b/test/story/event/handler/manager_test.exs
@@ -7,6 +7,7 @@ defmodule Helix.Story.Event.Handler.ManagerTest do
   alias Helix.Server.Query.Motherboard, as: MotherboardQuery
   alias Helix.Server.Query.Server, as: ServerQuery
   alias Helix.Story.Model.Step
+  alias Helix.Story.Query.Context, as: ContextQuery
   alias Helix.Story.Query.Story, as: StoryQuery
 
   alias Helix.Test.Event.Helper, as: EventHelper
@@ -47,6 +48,9 @@ defmodule Helix.Story.Event.Handler.ManagerTest do
 
       # Which happens to be the first one
       assert step.name == Step.first_step_name()
+
+      # And the Story.Context entry has been created for that Entity
+      assert ContextQuery.fetch(entity.entity_id)
     end
   end
 end

--- a/test/story/internal/context_test.exs
+++ b/test/story/internal/context_test.exs
@@ -1,0 +1,122 @@
+defmodule Helix.Story.Internal.ContextTest do
+
+  use Helix.Test.Case.Integration
+
+  alias Helix.Story.Model.Story
+  alias Helix.Story.Internal.Context, as: ContextInternal
+  alias Helix.Story.Repo, as: StoryRepo
+
+  alias HELL.TestHelper.Random
+  alias Helix.Test.Entity.Setup, as: EntitySetup
+  alias Helix.Test.Story.Setup, as: StorySetup
+
+  describe "fetch/1" do
+    test "returns the row, formatting it" do
+      # The row we'll retrieve has the following context:
+      context =
+        %{
+          foo: %{
+            bar: 1,
+            baz: %{vai: "curintia"},
+            bab: "bage"
+          }
+        }
+
+      # Context much
+      {story_context, _} = StorySetup.Context.context(context: context)
+
+      entry = ContextInternal.fetch(story_context.entity_id)
+
+      assert %Story.Context{} = entry
+      assert entry.context == context
+    end
+
+    test "returns empty when nothing is found" do
+      refute ContextInternal.fetch(EntitySetup.id())
+    end
+  end
+
+  describe "fetch_for_update/1" do
+    test "returns the row, formatting it" do
+      context = %{foo: %{bar: [1, "2", %{tr: "es"}]}}
+      {story_context, _} = StorySetup.Context.context(context: context)
+
+      StoryRepo.transaction fn ->
+        entry = ContextInternal.fetch_for_update(story_context.entity_id)
+
+        assert entry.context == context
+      end
+    end
+
+    test "blows up when not in transaction" do
+      assert_raise RuntimeError, fn ->
+        ContextInternal.fetch_for_update(EntitySetup.id())
+      end
+    end
+  end
+
+  describe "create/1" do
+    test "creates the entry for entity" do
+      entity_id = EntitySetup.id()
+
+      assert {:ok, context} = ContextInternal.create(entity_id)
+
+      assert context.entity_id == entity_id
+      assert Enum.empty?(context.context)
+    end
+  end
+
+  describe "save/2" do
+    test "appends the entry (on empty context)" do
+      {story_context, _} = StorySetup.Context.context()
+
+      # Empty context
+      assert Enum.empty?(story_context.context)
+
+      entry = %{field: %{sub: Random.number()}}
+
+      assert {:ok, new_story_context} =
+        ContextInternal.save(story_context.entity_id, entry, [:field, :sub])
+
+      assert new_story_context.context == entry
+    end
+
+    test "appends the entry (on existing, non-conflicting context)" do
+      # Current context
+      cur_context =
+        %{
+          foo: %{bar: 1},
+          tro: %{lo: "lo"}
+        }
+
+      {story_context, _} = StorySetup.Context.context(context: cur_context)
+
+      # We want to add this entry
+      entry = %{foo: %{baz: 2}}
+
+      assert {:ok, new_story_context} =
+        ContextInternal.save(story_context.entity_id, entry, [:foo, :baz])
+
+      # Expected context (previous one + recently added entry)
+      expected_context =
+        %{
+          foo: %{bar: 1, baz: 2},
+          tro: %{lo: "lo"}
+        }
+
+      assert new_story_context.context == expected_context
+    end
+
+    test "refuses to append an entry that is already set" do
+      cur_context = %{foo: %{bar: 1}}
+      {story_context, _} = StorySetup.Context.context(context: cur_context)
+
+      # We are trying to set `foo.bar = 2`, but it's already set as 1!
+      entry = %{foo: %{bar: 2}}
+
+      assert {:error, reason} =
+        ContextInternal.save(story_context.entity_id, entry, [:foo, :bar])
+      assert reason == :path_exists
+    end
+  end
+end

--- a/test/story/model/context_test.exs
+++ b/test/story/model/context_test.exs
@@ -1,0 +1,26 @@
+defmodule Helix.Story.Model.Story.ContextTest do
+
+  use ExUnit.Case, async: true
+
+  alias Helix.Server.Model.Server
+  alias Helix.Story.Model.Story
+
+  alias Helix.Test.Story.Setup, as: StorySetup
+
+  describe "format/1" do
+    test "handles Helix IDs" do
+      server_id = Server.ID.generate()
+
+      context = %{foo: %{server_id: Story.Context.store_id(server_id)}}
+      {fake_story_context, _} = StorySetup.Context.context(context: context)
+
+      assert is_binary(fake_story_context.context.foo.server_id.__id__)
+      assert is_binary(fake_story_context.context.foo.server_id.__root__)
+
+      story_context = Story.Context.format(fake_story_context)
+
+      # Xupa
+      assert story_context.context.foo.server_id == server_id
+    end
+  end
+end

--- a/test/story/model/story_email_test.exs
+++ b/test/story/model/story_email_test.exs
@@ -95,7 +95,10 @@ defmodule Helix.Story.Model.Story.EmailTest do
 
       formatted = Story.Email.format(%{entry| emails: shuffled_emails})
 
-      sorted_emails = Enum.sort(entry.emails, &(&2.timestamp >= &1.timestamp))
+      sorted_emails =
+        Enum.sort(
+          entry.emails, &(DateTime.compare(&2.timestamp, &1.timestamp) == :gt)
+        )
 
       assert formatted.emails == sorted_emails
     end

--- a/test/story/query/context_test.exs
+++ b/test/story/query/context_test.exs
@@ -1,0 +1,60 @@
+defmodule Helix.Story.Query.ContextTest do
+
+  use Helix.Test.Case.Integration
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Story.Query.Context, as: ContextQuery
+
+  alias Helix.Test.Story.Setup, as: StorySetup
+
+  describe "get/2" do
+    test "returns root field when found" do
+      context = %{foo: %{bar: [1, 2, 3]}}
+      {story_context, _} = StorySetup.Context.context(context: context)
+
+      # Searching from entity
+      assert context.foo == ContextQuery.get(story_context.entity_id, :foo)
+
+      # Searching from Story.Context
+      assert context.foo == ContextQuery.get(story_context, :foo)
+    end
+
+    test "returns empty (nil) when not found" do
+      context = %{foo: %{bar: [1, 2, 3]}}
+      {story_context, _} = StorySetup.Context.context(context: context)
+
+      # Searching from entity
+      refute ContextQuery.get(Entity.ID.generate(), :wat)
+      refute ContextQuery.get(story_context.entity_id, :wat)
+
+      # Searching from Story.Context
+      refute ContextQuery.get(story_context, :fool)
+    end
+  end
+
+  describe "get/3" do
+    test "returns arbitrarily nested subfields" do
+      context = %{foo: %{bar: %{baz: %{inga: 42}}}}
+      {%{entity_id: entity_id}, _} =
+        StorySetup.Context.context(context: context)
+
+      assert context.foo.bar == ContextQuery.get(entity_id, :foo, :bar)
+      assert context.foo.bar.baz ==
+        ContextQuery.get(entity_id, :foo, [:bar, :baz])
+      assert 42 == ContextQuery.get(entity_id, :foo, [:bar, :baz, :inga])
+    end
+
+    test "returns empty (nil) when not found" do
+      context = %{foo: %{bar: %{baz: %{inga: 42}}}}
+      {story_context = %{entity_id: entity_id}, _} =
+        StorySetup.Context.context(context: context)
+
+      # Searching from entity
+      refute ContextQuery.get(entity_id, :foo, :ba)
+      refute ContextQuery.get(entity_id, :foo, [:bar, :baz, :uca])
+
+      # Searching from Story.Context
+      refute ContextQuery.get(story_context, [:w, :a, :t])
+    end
+  end
+end

--- a/test/support/story/setup/context.ex
+++ b/test/support/story/setup/context.ex
@@ -1,0 +1,39 @@
+defmodule Helix.Test.Story.Setup.Context do
+
+  alias Ecto.Changeset
+  alias Helix.Story.Model.Story
+  alias Helix.Story.Repo, as: StoryRepo
+
+  alias Helix.Test.Entity.Setup, as: EntitySetup
+
+  @doc """
+  See docs on `fake_context/1`.
+  """
+  def context(opts \\ []) do
+    {story_context, related} = fake_context(opts)
+    inserted = StoryRepo.insert!(story_context)
+    {inserted, related}
+  end
+
+  @doc """
+  Opts:
+  - entity_id: Specify entity ID. Defaults to randomly generated (fake) entity
+  - context: Specify context value. Defaults to empty (%{})
+  """
+  def fake_context(opts \\ []) do
+    entity_id = Keyword.get(opts, :entity_id, EntitySetup.id())
+    context = Keyword.get(opts, :context, %{})
+
+    story_context =
+      %Story.Context{
+        entity_id: entity_id,
+        context: context
+      }
+
+    changeset = Changeset.change(story_context)
+
+    related = %{changeset: changeset}
+
+    {story_context, related}
+  end
+end


### PR DESCRIPTION
Story.Context is used for medium- to long-term persistence of arbitrary Storyline data.

Not to confuse with Story.Manager, which is used for structured data used throughout the entire Storyline. Short-lived data that span only one or a few steps should be persisted on Story.Step meta.

- [x] Automatic (transparent) handling of Helix IDs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/363)
<!-- Reviewable:end -->

  