### PR TITLE
Enhance Maroto capabilities for manual testing

### DIFF
--- a/lib/websocket/channel.ex
+++ b/lib/websocket/channel.ex
@@ -50,10 +50,10 @@ defmodule Helix.Websocket.Channel do
 
           with \
             true <- not is_nil(GenServer.whereis(interceptor)),
-            response = {_, _} <-
+            {status, response} <-
               GenServer.call(interceptor, {:intercept, unquote(name)})
           do
-            {:reply, response, socket}
+            {:reply, {status, %{data: response}}, socket}
           else
             _ ->
               unquote(request).new(params, socket)

--- a/lib/websocket/channel.ex
+++ b/lib/websocket/channel.ex
@@ -28,15 +28,40 @@ defmodule Helix.Websocket.Channel do
   specify both the topic name (which will be used to listen to incoming
   messages) and the corresponding request handler. The request handler must
   implement the Requestable protocol. See `Helix.Websocket.Request`.
+
+  On `:dev` and `:test` environments we include the Interceptor, which may be
+  used for testing purposes. This code does not exist on the :prod environment.
   """
   defmacro topic(name, request) do
-    quote do
+    if Mix.env == :prod do
+      quote do
 
-      def handle_in(unquote(name), params, socket) do
-        unquote(request).new(params, socket)
-        |> Websocket.handle_request(socket)
+        def handle_in(unquote(name), params, socket) do
+          unquote(request).new(params, socket)
+          |> Websocket.handle_request(socket)
+        end
+
       end
+    else
+      quote do
 
+        def handle_in(unquote(name), params, socket) do
+          interceptor = :channel_interceptor
+
+          with \
+            true <- not is_nil(GenServer.whereis(interceptor)),
+            response = {_, _} <-
+              GenServer.call(interceptor, {:intercept, unquote(name)})
+          do
+            {:reply, response, socket}
+          else
+            _ ->
+              unquote(request).new(params, socket)
+              |> Websocket.handle_request(socket)
+          end
+        end
+
+      end
     end
   end
 

--- a/test/support/account/helper.ex
+++ b/test/support/account/helper.ex
@@ -1,0 +1,13 @@
+defmodule Helix.Test.Account.Helper do
+
+  import Ecto.Query, only: [from: 1]
+
+  alias Helix.Account.Model.Account
+  alias Helix.Account.Repo, as: AccountRepo
+
+  @doc """
+  Fetches all accounts
+  """
+  def get_all,
+    do: AccountRepo.all(from a in Account)
+end

--- a/test/support/channel/interceptor.ex
+++ b/test/support/channel/interceptor.ex
@@ -4,28 +4,50 @@ defmodule Helix.Test.Channel.Interceptor do
 
   @registry_name :channel_interceptor
 
+  # External API
+
   def start_link,
     do: GenServer.start_link(__MODULE__, %{}, name: @registry_name)
 
-  def register_intercept(request_name, response) when is_tuple(response) do
+  def intercept_once(endpoint, response),
+    do: add_intercept(endpoint, response, :once)
+
+  def intercept_forever(endpoint, response),
+    do: add_intercept(endpoint, response, :forevis)
+
+  def stop_intercept(endpoint),
+    do: GenServer.call(@registry_name, {:stop_intercept, endpoint})
+
+  defp add_intercept(endpoint, response, lifetime) when is_tuple(response) do
     GenServer.call(
-      @registry_name, {:register_intercept, request_name, response}
+      @registry_name, {:add_intercept, endpoint, {response, lifetime}}
     )
   end
 
-  def intercept(request_name),
-    do: GenServer.call(@registry_name, {:intercept, request_name})
+  def intercept(endpoint),
+    do: GenServer.call(@registry_name, {:intercept, endpoint})
 
-  def handle_call({:register_intercept, request_name, response}, _, state),
-    do: {:reply, :ok, put_in(state, [request_name], response)}
+  # Callbacks
 
-  def handle_call({:intercept, request_name}, _, state) do
-    # Get expected response
-    response = Map.get(state, request_name)
+  def handle_call({:add_intercept, endpoint, entry}, _, state),
+    do: {:reply, :ok, put_in(state, [endpoint], entry)}
 
-    # No longer intercept the request
-    new_state = Map.delete(state, request_name)
+  def handle_call({:stop_intercept, endpoint}, _, state),
+    do: {:reply, :ok, remove_entry(state, endpoint)}
 
-    {:reply, response, new_state}
+  def handle_call({:intercept, endpoint}, _, state) do
+    case Map.get(state, endpoint) do
+      {response, :once} ->
+        {:reply, response, remove_entry(state, endpoint)}
+
+      {response, :forevis} ->
+        {:reply, response, state}
+
+      nil ->
+        {:reply, nil, state}
+    end
   end
+
+  defp remove_entry(state, endpoint),
+    do: Map.delete(state, endpoint)
 end

--- a/test/support/channel/interceptor.ex
+++ b/test/support/channel/interceptor.ex
@@ -1,0 +1,31 @@
+defmodule Helix.Test.Channel.Interceptor do
+
+  use GenServer
+
+  @registry_name :channel_interceptor
+
+  def start_link,
+    do: GenServer.start_link(__MODULE__, %{}, name: @registry_name)
+
+  def register_intercept(request_name, response) when is_tuple(response) do
+    GenServer.call(
+      @registry_name, {:register_intercept, request_name, response}
+    )
+  end
+
+  def intercept(request_name),
+    do: GenServer.call(@registry_name, {:intercept, request_name})
+
+  def handle_call({:register_intercept, request_name, response}, _, state),
+    do: {:reply, :ok, put_in(state, [request_name], response)}
+
+  def handle_call({:intercept, request_name}, _, state) do
+    # Get expected response
+    response = Map.get(state, request_name)
+
+    # No longer intercept the request
+    new_state = Map.delete(state, request_name)
+
+    {:reply, response, new_state}
+  end
+end

--- a/test/support/maroto.ex
+++ b/test/support/maroto.ex
@@ -11,6 +11,7 @@ defmodule Helix.Maroto do
       unquote(marote_helix())
       unquote(marote_aliases())
       unquote(marote_helpers())
+      unquote(marote_tools())
 
       use Helix.Maroto.Functions
 
@@ -128,6 +129,16 @@ defmodule Helix.Maroto do
       alias Helix.Test.Story.Helper, as: StoryHelper
       alias Helix.Test.Universe.Bank.Helper, as: BankHelper
       alias Helix.Test.Universe.NPC.Helper, as: NPCHelper
+
+    end
+  end
+
+  defp marote_tools do
+    quote do
+
+      alias Helix.Test.Channel.Interceptor
+
+      Interceptor.start_link()
 
     end
   end

--- a/test/support/maroto.ex
+++ b/test/support/maroto.ex
@@ -14,6 +14,8 @@ defmodule Helix.Maroto do
 
       use Helix.Maroto.Functions
 
+      :noix
+
     end
   end
 
@@ -128,38 +130,5 @@ defmodule Helix.Maroto do
       alias Helix.Test.Universe.NPC.Helper, as: NPCHelper
 
     end
-  end
-end
-
-defmodule Helix.Maroto.Functions do
-
-  alias Helix.Account.Action.Flow.Account, as: AccountFlow
-
-  alias HELL.TestHelper.Random
-
-  defmacro __using__(_) do
-    quote do
-
-      import Helix.Maroto.Functions
-    end
-  end
-
-  @doc """
-  Opts:
-
-  - email: email
-  - user: Username.
-  - pass: Password.
-  """
-  def create_account(opts \\ []) do
-    email = Keyword.get(opts, :email, Random.email())
-    user = Keyword.get(opts, :user, Random.username())
-    pass = Keyword.get(opts, :pass, Random.string(min: 8, max: 10))
-
-    related = %{email: email, user: user, pass: pass}
-
-    {:ok, account} = AccountFlow.create(email, user, pass)
-
-    {account, related}
   end
 end

--- a/test/support/maroto.sh
+++ b/test/support/maroto.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Go to Helix root
+cd $(dirname $(realpath $0))
+cd ../../
+
+HELIX_ROOT=$PWD
+MIX_FILE=$HELIX_ROOT/mix.exs
+IEX_FILE=$HELIX_ROOT/.iex.exs
+
+# Replace elixirc option; ensures `test/support` gets compiled on :dev
+ed -s $HELIX_ROOT/mix.exs <<< $',s/(:test)/(_)/g\nw'
+
+# Create temporary IEx file with instructions
+echo "IO.puts \"\n\nType 'use Helix.Maroto' for maximum marotagem!!11!\n\n\"" > $IEX_FILE
+
+# Run Helix interactively
+iex -S mix
+
+# Clean up any changes
+git checkout $MIX_FILE
+rm $IEX_FILE

--- a/test/support/maroto/client.ex
+++ b/test/support/maroto/client.ex
@@ -7,6 +7,7 @@ defmodule Helix.Maroto.ClientTools do
   alias Helix.Server.Model.Server
 
   alias Helix.Test.Account.Helper, as: AccountHelper
+  alias Helix.Test.Channel.Interceptor
   alias Helix.Test.Server.Helper, as: ServerHelper
 
   defmacro __using(_) do
@@ -17,8 +18,112 @@ defmodule Helix.Maroto.ClientTools do
     end
   end
 
+  @doc """
+  Intercepts `endpoint` so, the first time a request goes through, it's answer
+  will be `{status, payload}`, where `status` is either `:ok` or `:error`, and
+  payload is a map. After the first intercept, upcoming calls to the same
+  endpoint will behave as usual.
+
+  NOTE: The actual payload sent will be wrapped into the format required by
+  Client, so it would probably reply something like:
+
+    %{data: `payload`, meta: %{request_id: nil}}
+  """
+  def intercept_once(endpoint, response = {status, payload}) do
+    unless status in [:ok, :error],
+      do: raise "Invalid status #{status}. Use either `:ok` or `:error`"
+
+    unless is_map(payload),
+      do: raise "Payload must be a map, got #{inspect payload}"
+
+    Interceptor.intercept_once(endpoint, response)
+  end
+
+  @doc """
+  Intercepts `endpoint`, answering `{status, payload}`, where `status` is either
+  `:ok` or `:error`, and payload is a map. It will keep intercepting until
+  `stop_intercept` is called.
+
+  NOTE: The actual payload sent will be wrapped into the format required by
+  Client, so it would probably reply something like:
+
+  %{data: `payload`, meta: %{request_id: nil}}
+  """
+  def intercept_forever(endpoint, response = {status, payload}) do
+    unless status in [:ok, :error],
+      do: raise "Invalid status #{status}. Use either `:ok` or `:error`"
+
+    unless is_map(payload),
+      do: raise "Payload must be a map, got #{inspect payload}"
+
+    Interceptor.intercept_forever(endpoint, response)
+  end
+
+  @doc """
+  Stops an on-going intercept defined with `intercept_forever/2`
+  """
+  def stop_intercept(endpoint),
+    do: Interceptor.stop_intercept(endpoint)
+
+  @doc """
+  Broadcasts an event to the Client.
+
+  # Channels:
+
+  The first parameter of `testcast/4` is used to identify which channel should
+  receive the broadcast.
+
+  ## Account
+
+  - "account": Sends the event to all registered accounts
+  - "account:<ID>": Sends the event to the specific topic
+  - Account.t: Sends the event to the given account
+  - Entity.t: Sends the event to the given entity (entity == account here)
+
+  ## Server
+
+  - "server": Sends the event to all registered servers
+  - "server:<ID>": Sends the event to the specific server (identified by ID)
+  - "server:<N:IP>": Sends the event to the specific server (identified by NIP)
+  - Server.t: Sends the event to the given server
+
+  # Events
+
+  The remaining params are used to identify which event should be broadcasted.
+
+  ## Event.t
+
+  If you pass a valid Event.t (created from EventSetup.*) I'll do all the
+  hard work to figure out the event payload as it would be used by Helix and
+  send you back. This is the most reliable way to use `testcast`.
+
+  NOTE: In order for this to work, the received Event.t must implement the
+  Notificable protocol (if it doesn't, you'd never receive the event anyway)
+
+  ## Raw payload
+
+  If you don't have a valid Event.t laying around, you can specify the raw
+  payload you should receive, as well as the expected event name. This is
+  especially useful if you want to test an event that does not exist on Helix.
+
+  NOTE: The actual event received by the Client will be wrapped into the
+  expected format, so it would become something like:
+
+    %{data: `payload`, meta: %{request_id: _, event_id: _, process_id: _}}
+
+  # Opts
+
+  Regardless of the event you've passed as parameter (Event.t or raw payload),
+  you may specify some metadata.
+
+  - request_id: Set the `request_id` value within `meta`
+  - event_id: Set the `event_id` value within `meta`
+  - process_id: Set the `process_id` value within `meta`
+
+  Missing something? Let me know!
+  """
   # (`trash` is a workaround to let us group these functions as we want)
-  def testcast(topic, event, opts_or_name \\ [], opts_or_trash \\ [])
+  def testcast(topic, event_or_payload, opts_or_name \\ [], opts_or_trash \\ [])
 
   # Account channel
 
@@ -83,7 +188,7 @@ defmodule Helix.Maroto.ClientTools do
   defp build_topic(entity = %Entity{}),
     do: "account:" <> to_string(entity.entity_id)
 
-  defp build_event(event = %_{__meta__: _}, _opts) do
+  defp build_event(event = %_{__meta__: _}, opts) do
     {:ok, payload} = Notificable.generate_payload(event, %{})
 
     %{
@@ -91,13 +196,33 @@ defmodule Helix.Maroto.ClientTools do
       event: Notificable.get_event_name(event),
       meta: Event.Meta.render(event)
     }
+    |> merge_meta(opts)
   end
 
-  defp build_event(payload = %{}, name, _opts) do
+  defp build_event(payload = %{}, name, opts) do
     %{
       data: payload,
       event: to_string(name),
-      meta: %{}
+      meta: empty_meta()
     }
+    |> merge_meta(opts)
+  end
+
+  defp empty_meta,
+    do: Event.Meta.render(%{__meta__: nil})
+
+  defp merge_meta(event = %{meta: meta}, opts) do
+    request_id = Keyword.get(opts, :request_id, meta.request_id)
+    event_id = Keyword.get(opts, :event_id, meta.event_id)
+    process_id = Keyword.get(opts, :process_id, meta.process_id)
+
+    new_meta =
+      %{
+        request_id: request_id,
+        event_id: event_id,
+        process_id: process_id,
+      }
+
+    %{event| meta: new_meta}
   end
 end

--- a/test/support/maroto/client.ex
+++ b/test/support/maroto/client.ex
@@ -1,0 +1,103 @@
+defmodule Helix.Maroto.ClientTools do
+
+  alias Helix.Event
+  alias Helix.Event.Notificable
+  alias Helix.Account.Model.Account
+  alias Helix.Entity.Model.Entity
+  alias Helix.Server.Model.Server
+
+  alias Helix.Test.Account.Helper, as: AccountHelper
+  alias Helix.Test.Server.Helper, as: ServerHelper
+
+  defmacro __using(_) do
+    quote do
+
+      import Helix.Maroto.Client
+
+    end
+  end
+
+  # (`trash` is a workaround to let us group these functions as we want)
+  def testcast(topic, event, opts_or_name \\ [], opts_or_trash \\ [])
+
+  # Account channel
+
+  def testcast("account", event = %_{__meta__: _}, opts, _),
+    do: broadcast_all("account", build_event(event, opts))
+  def testcast("account", payload = %{}, name, opts),
+    do: broadcast_all("account", build_event(payload, name, opts))
+  def testcast(account = %Account{}, event = %_{__meta__: _}, opts, _),
+    do: broadcast(build_topic(account), build_event(event, opts))
+  def testcast(entity = %Entity{}, event = %_{__meta__: _}, opts, _),
+    do: broadcast(build_topic(entity), build_event(event, opts))
+  def testcast(account = %Account{}, payload = %{}, name, opts),
+    do: broadcast(build_topic(account), build_event(payload, name, opts))
+  def testcast(entity = %Entity{}, payload = %{}, name, opts),
+    do: broadcast(build_topic(entity), build_event(payload, name, opts))
+  def testcast(topic = "account:" <> _, event = %_{__meta__: _}, opts, _),
+    do: broadcast(topic, build_event(event, opts))
+  def testcast(topic = "account:" <> _, payload = %{}, name, opts),
+    do: broadcast(topic, build_event(payload, name, opts))
+
+  # Server channel
+
+  def testcast("server", event = %_{__meta__: _}, opts, _),
+    do: broadcast_all("server", build_event(event, opts))
+  def testcast("server", payload = %{}, name, opts),
+    do: broadcast_all("server", build_event(payload, name, opts))
+  def testcast(server = %Server{}, event = %_{__meta__: _}, opts, _),
+    do: broadcast(build_topic(server), build_event(event, opts))
+  def testcast(server = %Server{}, payload = %{}, name, opts),
+    do: broadcast(build_topic(server), build_event(payload, name, opts))
+  def testcast(topic = "server:" <> _, event = %_{__meta__: _}, opts, _),
+    do: broadcast(topic, build_event(event, opts))
+  def testcast(topic = "server:" <> _, payload = %{}, name, opts),
+    do: broadcast(topic, build_event(payload, name, opts))
+
+  # Broadcasters
+
+  defp broadcast(topic, payload) when not is_binary(topic),
+    do: broadcast(to_string(topic), payload)
+  defp broadcast(topic, payload) do
+    Helix.Endpoint.broadcast(topic, "event_marote", payload)
+
+    IO.puts "Broadcasted to #{topic} -- #{inspect payload}"
+  end
+
+  defp broadcast_all("account", payload) do
+    AccountHelper.get_all()
+    |> Enum.map(&(broadcast(build_topic(&1), payload)))
+  end
+
+  defp broadcast_all("server", payload) do
+    ServerHelper.get_all()
+    |> Enum.map(&(broadcast(build_topic(&1), payload)))
+  end
+
+  # Builders
+
+  defp build_topic(server = %Server{}),
+    do: "server:" <> to_string(server.server_id)
+  defp build_topic(account = %Account{}),
+    do: "account:" <> to_string(account.account_id)
+  defp build_topic(entity = %Entity{}),
+    do: "account:" <> to_string(entity.entity_id)
+
+  defp build_event(event = %_{__meta__: _}, _opts) do
+    {:ok, payload} = Notificable.generate_payload(event, %{})
+
+    %{
+      data: payload,
+      event: Notificable.get_event_name(event),
+      meta: Event.Meta.render(event)
+    }
+  end
+
+  defp build_event(payload = %{}, name, _opts) do
+    %{
+      data: payload,
+      event: to_string(name),
+      meta: %{}
+    }
+  end
+end

--- a/test/support/maroto/functions.ex
+++ b/test/support/maroto/functions.ex
@@ -1,0 +1,34 @@
+defmodule Helix.Maroto.Functions do
+
+  alias Helix.Account.Action.Flow.Account, as: AccountFlow
+
+  alias HELL.TestHelper.Random
+
+  defmacro __using__(_) do
+    quote do
+
+      import Helix.Maroto.Functions
+      import Helix.Maroto.ClientTools
+
+    end
+  end
+
+  @doc """
+  Opts:
+
+  - email: email
+  - user: Username.
+  - pass: Password.
+  """
+  def create_account(opts \\ []) do
+    email = Keyword.get(opts, :email, Random.email())
+    user = Keyword.get(opts, :user, Random.username())
+    pass = Keyword.get(opts, :pass, Random.string(min: 8, max: 10))
+
+    related = %{email: email, user: user, pass: pass}
+
+    {:ok, account} = AccountFlow.create(email, user, pass)
+
+    {account, related}
+  end
+end

--- a/test/support/server/helper.ex
+++ b/test/support/server/helper.ex
@@ -1,6 +1,8 @@
 # credo:disable-for-this-file Credo.Check.Refactor.CyclomaticComplexity
 defmodule Helix.Test.Server.Helper do
 
+  import Ecto.Query, only: [from: 1]
+
   alias Ecto.Changeset
   alias Helix.Cache.Query.Cache, as: CacheQuery
   alias Helix.Entity.Query.Entity, as: EntityQuery
@@ -14,9 +16,9 @@ defmodule Helix.Test.Server.Helper do
 
   alias Helix.Test.Network.Helper, as: NetworkHelper
 
-  @internet NetworkHelper.internet_id()
+  @internet_id NetworkHelper.internet_id()
 
-  def get_ip(server, network_id \\ @internet)
+  def get_ip(server, network_id \\ @internet_id)
   def get_ip(server = %Server{}, network_id),
     do: get_ip(server.server_id, network_id)
   def get_ip(server_id = %Server.ID{}, network_id),
@@ -123,4 +125,10 @@ defmodule Helix.Test.Server.Helper do
     |> ServerQuery.fetch()
     |> update_server_mobo(spec_id)
   end
+
+  @doc """
+  Fetches all servers
+  """
+  def get_all,
+    do: ServerRepo.all(from s in Server)
 end


### PR DESCRIPTION
- [x] RequestInterceptor - Intercept requests, returning previously defined responses (`:dev` and `:test` ONLY!)
- [x] Broadcast events to all players 
- [x] Maroto interfaces
- [x] Automatic script for quick HelixMaroto launch
- [x] Broadcast to servers identified by NIP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/373)
<!-- Reviewable:end -->
