### PR TITLE
Enable Steps to be restarted

### DIFF
--- a/events.json
+++ b/events.json
@@ -116,7 +116,7 @@
       "receives": ["All"],
       "emits": [
         "Story.Step.Proceeded",
-        "Story.Step.Failed",
+        "Story.Step.Restarted",
         "Steppable (custom)"
       ]
     },
@@ -157,9 +157,6 @@
     ],
     "Software.Software.LogForger": [
       "Process.Created"
-    ],
-    "Story.Manager": [
-      "Story.Proceeded"
     ]
   },
   "process_conclusion": [
@@ -183,9 +180,13 @@
     "Process.Created",
     "Process.Completed",
     "Process.Killed",
+    "File.Added",
+    "File.Deleted",
     "File.Uploaded",
     "StoryEmailSentEvent",
     "StoryReplySentEvent",
+    "Story.Step.Restarted",
+    "Story.Step.Proceeded",
     "Virus.Installed",
     "Virus.InstallFailed"
   ],
@@ -197,8 +198,13 @@
           "emits": []
         },
         "DownloadCracker": {
-          "filters": ["File.Downloaded"],
-          "emits": []
+          "filters": [
+            "File.Downloaded",
+            "File.Deleted"
+          ],
+          "emits": [
+            "File.Added"
+          ]
         }
       }
     }

--- a/events.json
+++ b/events.json
@@ -196,7 +196,7 @@
           "filters": ["Account.Created"],
           "emits": []
         },
-        "DownloadCrackerPublicFTP": {
+        "DownloadCracker": {
           "filters": ["File.Downloaded"],
           "emits": []
         }

--- a/lib/core/listener/model/owner.ex
+++ b/lib/core/listener/model/owner.ex
@@ -45,6 +45,7 @@ defmodule Helix.Core.Listener.Model.Owner do
     %__MODULE__{}
     |> cast(params, @creation_fields)
     |> validate_required(@required_fields)
+    |> unique_constraint(:owner_id_object_id_event_subscriber)
   end
 
   defmodule Query do

--- a/lib/event/dispatcher.ex
+++ b/lib/event/dispatcher.ex
@@ -172,6 +172,7 @@ defmodule Helix.Event.Dispatcher do
   event SoftwareEvent.Cracker.Bruteforce.Processed
   event SoftwareEvent.Cracker.Overflow.Processed
   event SoftwareEvent.File.Added
+  event SoftwareEvent.File.Deleted
   event SoftwareEvent.File.Downloaded
   event SoftwareEvent.File.DownloadFailed
   event SoftwareEvent.File.Install.Processed
@@ -235,6 +236,7 @@ defmodule Helix.Event.Dispatcher do
   event StoryEvent.Reply.Sent
   event StoryEvent.Step.ActionRequested
   event StoryEvent.Step.Proceeded
+  event StoryEvent.Step.Restarted
 
   # Custom handlers
   event StoryEvent.Reply.Sent,

--- a/lib/hell/hack.ex
+++ b/lib/hell/hack.ex
@@ -53,8 +53,8 @@ defmodule HELL.Hack.Experience do
         {:render, 3}
       ],
       "Elixir.Helix.Story.Model.Steppable" => [
-        {:start, 2},
-        {:setup, 2},
+        {:start, 1},
+        {:setup, 1},
         {:handle_event, 3},
         {:complete, 1},
         {:restart, 3},

--- a/lib/hell/hack.ex
+++ b/lib/hell/hack.ex
@@ -53,10 +53,11 @@ defmodule HELL.Hack.Experience do
         {:render, 3}
       ],
       "Elixir.Helix.Story.Model.Steppable" => [
+        {:start, 2},
         {:setup, 2},
         {:handle_event, 3},
         {:complete, 1},
-        {:fail, 1},
+        {:restart, 3},
         {:next_step, 1},
         {:get_contact, 1},
         {:format_meta, 1},

--- a/lib/software/event/handler/filesystem.ex
+++ b/lib/software/event/handler/filesystem.ex
@@ -22,7 +22,7 @@ defmodule Helix.Software.Event.Handler.Filesystem do
   # Existing entries being updated
 
   # Existing entries being removed
-  # TODO FileDeletedEvent
+  # TODO FileDeletedEvent #384
 
   # Generic notifiers
 

--- a/lib/software/event/handler/filesystem.ex
+++ b/lib/software/event/handler/filesystem.ex
@@ -22,6 +22,7 @@ defmodule Helix.Software.Event.Handler.Filesystem do
   # Existing entries being updated
 
   # Existing entries being removed
+  # TODO FileDeletedEvent
 
   # Generic notifiers
 

--- a/lib/software/make/file.ex
+++ b/lib/software/make/file.ex
@@ -18,11 +18,14 @@ defmodule Helix.Software.Make.File do
   @typep file_parent :: Server.t | Storage.id
   @typep version :: File.Module.version
 
+  @typep file_return(type) ::
+    {:ok, File.t_of_type(type), %{}, [FileAddedEvent.t]}
+
   @doc """
   Generates a cracker.
   """
   @spec cracker(file_parent, cracker_modules, data) ::
-    {:ok, File.t_of_type(:cracker), %{}, []}
+    file_return(:cracker)
   def cracker(parent, modules, data \\ %{}),
     do: file(parent, :cracker, modules, data)
 
@@ -34,7 +37,7 @@ defmodule Helix.Software.Make.File do
   end
 
   @spec file(file_parent, Software.type, modules, data) ::
-    {:ok, File.t, %{}, []}
+    file_return(Software.type)
   defp file(server = %Server{}, type, modules, data) do
     server
     |> CacheQuery.from_server_get_storages!()

--- a/lib/software/make/pftp.ex
+++ b/lib/software/make/pftp.ex
@@ -6,18 +6,18 @@ defmodule Helix.Software.Make.PFTP do
   alias Helix.Software.Model.PublicFTP
 
   @spec server(Server.t) ::
-    {:ok, PublicFTP.t, %{}}
+    {:ok, PublicFTP.t, %{}, []}
   def server(server = %Server{}) do
     {:ok, pftp} = PublicFTPFlow.enable_server(server)
 
-    {:ok, pftp, %{}}
+    {:ok, pftp, %{}, []}
   end
 
   @spec add_file(File.t, PublicFTP.t) ::
-    {:ok, PublicFTP.File.t, %{}}
+    {:ok, PublicFTP.File.t, %{}, []}
   def add_file(file = %File{}, pftp = %PublicFTP{}) do
     {:ok, pftp_file} = PublicFTPFlow.add_file(pftp, file)
 
-    {:ok, pftp_file, %{}}
+    {:ok, pftp_file, %{}, []}
   end
 end

--- a/lib/software/model/public_ftp.ex
+++ b/lib/software/model/public_ftp.ex
@@ -84,7 +84,7 @@ defmodule Helix.Software.Model.PublicFTP do
   @doc """
   Verifies whether the given server is active (enabled) or not.
   """
-  def is_active?(pftp = %__MODULE__{is_active: is_active?}),
+  def is_active?(%__MODULE__{is_active: is_active?}),
     do: is_active?
 
   @spec create_changeset(creation_params) ::

--- a/lib/software/model/public_ftp.ex
+++ b/lib/software/model/public_ftp.ex
@@ -79,6 +79,14 @@ defmodule Helix.Software.Model.PublicFTP do
   def disable_server(changeset = %Changeset{}),
     do: put_change(changeset, :is_active, false)
 
+  @spec is_active?(t) ::
+    boolean
+  @doc """
+  Verifies whether the given server is active (enabled) or not.
+  """
+  def is_active?(pftp = %__MODULE__{is_active: is_active?}),
+    do: is_active?
+
   @spec create_changeset(creation_params) ::
     changeset
   defp create_changeset(params) do

--- a/lib/software/query/public_ftp.ex
+++ b/lib/software/query/public_ftp.ex
@@ -5,7 +5,7 @@ defmodule Helix.Software.Query.PublicFTP do
   alias Helix.Software.Model.File
   alias Helix.Software.Model.PublicFTP
 
-  @spec fetch_file(File.t) ::
+  @spec fetch_file(File.idt) ::
     PublicFTP.File.t
     | nil
   @doc """
@@ -15,9 +15,11 @@ defmodule Helix.Software.Query.PublicFTP do
   - The PublicFTP server is active.
   """
   def fetch_file(file = %File{}),
-    do: PublicFTPInternal.fetch_file(file.file_id)
+    do: fetch_file(file.file_id)
+  def fetch_file(file_id = %File.ID{}),
+    do: PublicFTPInternal.fetch_file(file_id)
 
-  @spec fetch_server(Server.t) ::
+  @spec fetch_server(Server.idt) ::
     PublicFTP.t
     | nil
   @doc """
@@ -26,7 +28,9 @@ defmodule Helix.Software.Query.PublicFTP do
   Disabled/inactive servers are returned as well.
   """
   def fetch_server(server = %Server{}),
-    do: PublicFTPInternal.fetch(server.server_id)
+    do: fetch_server(server.server_id)
+  def fetch_server(server_id = %Server.ID{}),
+    do: PublicFTPInternal.fetch(server_id)
 
   @spec list_files(Server.idt) ::
     [File.t]

--- a/lib/story/action/flow/story.ex
+++ b/lib/story/action/flow/story.ex
@@ -30,7 +30,7 @@ defmodule Helix.Story.Action.Flow.Story do
       with \
         {:ok, _} <- ContextFlow.setup(entity),
         {:ok, story_step} <- StoryAction.proceed_step(first_step),
-        {:ok, _, events} <- Steppable.start(first_step, nil),
+        {:ok, _, events} <- Steppable.start(first_step),
         on_success(fn -> Event.emit(events, from: relay) end)
       do
         {:ok, story_step}

--- a/lib/story/action/flow/story.ex
+++ b/lib/story/action/flow/story.ex
@@ -30,7 +30,7 @@ defmodule Helix.Story.Action.Flow.Story do
       with \
         {:ok, _} <- ContextFlow.setup(entity),
         {:ok, story_step} <- StoryAction.proceed_step(first_step),
-        {:ok, _, events} <- Steppable.setup(first_step, nil),
+        {:ok, _, events} <- Steppable.start(first_step, nil),
         on_success(fn -> Event.emit(events, from: relay) end)
       do
         {:ok, story_step}

--- a/lib/story/internal/email.ex
+++ b/lib/story/internal/email.ex
@@ -64,6 +64,11 @@ defmodule Helix.Story.Internal.Email do
   def send_reply(step, reply_id),
     do: generic_send(step, reply_id, :player)
 
+  @spec rollback_email(Step.t, Step.email_id, Step.email_meta) ::
+    entry_email_repo_return
+  @doc """
+  Rollbacks the email history to the given checkpoint (`email_id`).
+  """
   def rollback_email(step, email_id, meta) do
     step
     |> fetch()

--- a/lib/story/make/story.ex
+++ b/lib/story/make/story.ex
@@ -13,7 +13,7 @@ defmodule Helix.Story.Make.Story do
   @typep char_related :: %{entity: Entity.t}
 
   @spec char(Network.id) ::
-    {:ok, Server.t, char_related}
+    {:ok, Server.t, char_related, []}
   def char(network_id = %Network.ID{}) do
     network = NetworkQuery.fetch(network_id)
     net_data =
@@ -28,7 +28,7 @@ defmodule Helix.Story.Make.Story do
       {:ok, entity, _} <- MakeEntity.entity(npc),
       {:ok, server, _} <- MakeServer.npc(entity, net_data)
     do
-      {:ok, server, %{entity: entity}}
+      {:ok, server, %{entity: entity}, []}
     end
   end
 end

--- a/lib/story/model/step.ex
+++ b/lib/story/model/step.ex
@@ -49,11 +49,19 @@ defmodule Helix.Story.Model.Step do
   @type contact :: Constant.t
   @type contact_id :: contact
 
+  @typedoc """
+  The `callback_action` type lists all possible actions that may be applied to
+  a step. Notably, one of them must be returned by `Steppable.handle_event/3`,
+  but it's also used in other contexts, including on `StepActionRequestedEvent`.
+
+  The action will be interpreted and applied at the StoryEventHandler.
+
+  Note that `:restart` also includes metadata (`reason` and `checkpoint`).
+  """
   @type callback_action ::
     :complete
-    | :fail
-    | :regenerate
     | :noop
+    | {:restart, reason :: atom, checkpoint :: email_id}
 
   @spec new(t, Event.t) ::
     t

--- a/lib/story/model/step.ex
+++ b/lib/story/model/step.ex
@@ -54,7 +54,7 @@ defmodule Helix.Story.Model.Step do
   a step. Notably, one of them must be returned by `Steppable.handle_event/3`,
   but it's also used in other contexts, including on `StepActionRequestedEvent`.
 
-  The action will be interpreted and applied at the StoryEventHandler.
+  The action will be interpreted and applied at the StoryHandler.
 
   Note that `:restart` also includes metadata (`reason` and `checkpoint`).
   """

--- a/lib/story/model/step/macros.ex
+++ b/lib/story/model/step/macros.ex
@@ -14,6 +14,7 @@ defmodule Helix.Story.Model.Step.Macros do
   alias Helix.Entity.Model.Entity
   alias Helix.Story.Model.Step
   alias Helix.Story.Action.Story, as: StoryAction
+  alias Helix.Story.Query.Story, as: StoryQuery
 
   alias Helix.Story.Event.Reply.Sent, as: StoryReplySentEvent
   alias Helix.Story.Event.Step.ActionRequested, as: StepActionRequestedEvent
@@ -38,7 +39,6 @@ defmodule Helix.Story.Model.Step.Macros do
           @emails Module.get_attribute(__MODULE__, :emails) || %{}
           @contact get_contact(unquote(contact), __MODULE__)
           @step_name Helix.Story.Model.Step.get_name(unquote(name))
-          @set false
 
           unquote(block)
 
@@ -310,14 +310,12 @@ defmodule Helix.Story.Model.Step.Macros do
     quote do
 
       @doc false
-      def setup(_, _) do
+      def setup(_) do
         nil
       end
 
     end
   end
-
-  alias Helix.Story.Model.Step.Macros.Setup, as: StepSetup
 
   defmacro setup_once(object, identifier, do: block),
     do: do_setup_once(object, identifier, [], block)
@@ -328,7 +326,8 @@ defmodule Helix.Story.Model.Step.Macros do
     fun_name = Utils.concat_atom(:find_, object)
 
     quote do
-      result = apply(StepSetup, unquote(fun_name), [unquote(id), unquote(opts)])
+      result =
+        apply(StoryQuery.Setup, unquote(fun_name), [unquote(id), unquote(opts)])
 
       with nil <- result do
         unquote(block)

--- a/lib/story/model/step/macros.ex
+++ b/lib/story/model/step/macros.ex
@@ -317,6 +317,11 @@ defmodule Helix.Story.Model.Step.Macros do
     end
   end
 
+  @doc """
+  `setup_once` is a helper to ease achieving idempotency on `Steppable.setup/1`.
+
+  It's a thin wrapper around `StoryQuery.Setup`, which does the heavy work.
+  """
   defmacro setup_once(object, identifier, do: block),
     do: do_setup_once(object, identifier, [], block)
   defmacro setup_once(object, identifier, opts, do: block),

--- a/lib/story/model/step/macros/setup.ex
+++ b/lib/story/model/step/macros/setup.ex
@@ -1,0 +1,58 @@
+defmodule Helix.Story.Model.Step.Macros.Setup do
+
+  alias HELL.Utils
+  alias Helix.Entity.Model.Entity
+  alias Helix.Entity.Query.Entity, as: EntityQuery
+  alias Helix.Server.Model.Server
+  alias Helix.Server.Query.Server, as: ServerQuery
+  alias Helix.Software.Model.File
+  alias Helix.Software.Model.PublicFTP
+  alias Helix.Software.Query.File, as: FileQuery
+  alias Helix.Software.Query.PublicFTP, as: PublicFTPQuery
+  alias Helix.Story.Model.Step
+  alias Helix.Story.Query.Context, as: ContextQuery
+
+  @spec find_char({Entity.id, Step.contact_id}, []) ::
+    {:ok, Server.t, %{entity: Entity.t}, []}
+    | nil
+  def find_char({entity_id = %Entity.ID{}, contact_id}, _opts) do
+    with \
+      context = %{} <- ContextQuery.get(entity_id, contact_id),
+      server = %{} <- ServerQuery.fetch(context.server_id),
+      entity = %{} <- EntityQuery.fetch(context.entity_id)
+    do
+      {:ok, server, %{entity: entity}, []}
+    end
+  end
+
+  def find_file(nil, _),
+    do: nil
+  def find_file(file_id = %File.ID{}, _opts) do
+    with file = %{} <- FileQuery.fetch(file_id) do
+      {:ok, file, %{}, []}
+    end
+  end
+
+  def find_pftp_server(nil, _opts),
+    do: nil
+  def find_pftp_server(server = %Server{}, opts),
+    do: find_pftp_server(server.server_id, opts)
+  def find_pftp_server(server_id = %Server.ID{}, _opts) do
+    with \
+      pftp = %{} <- PublicFTPQuery.fetch_server(server_id),
+      true <- PublicFTP.is_active?(pftp) || nil
+    do
+      {:ok, pftp, %{}, []}
+    end
+  end
+
+  def find_pftp_file(nil, _opts),
+    do: nil
+  def find_pftp_file(file = %File{}, opts),
+    do: find_pftp_file(file.file_id, opts)
+  def find_pftp_file(file_id = %File.ID{}, _opts) do
+    with pftp_file = %{} <- PublicFTPQuery.fetch_file(file_id) do
+      {:ok, pftp_file, %{}, []}
+    end
+  end
+end

--- a/lib/story/model/story/email.ex
+++ b/lib/story/model/story/email.ex
@@ -87,6 +87,35 @@ defmodule Helix.Story.Model.Story.Email do
     }
   end
 
+  def rollback_email(entry, email_id, meta) do
+    email = create_email(email_id, meta, :contact)
+
+    entry
+    |> change()
+    |> do_rollback_email(email)
+    |> generic_validations()
+  end
+
+  defp do_rollback_email(changeset, email) do
+    new_emails =
+      changeset
+      |> get_field(:emails)
+      |> Enum.reverse()
+
+      # Remove all emails sent after `email_id`
+      |> Enum.drop_while(&(&1.id != email.id))
+
+      # Also remove `email_id`...
+      |> List.delete_at(0)
+
+      # Which will be replaced by the new `email`
+      |> List.insert_at(0, email)
+      |> Enum.reverse()
+
+    changeset
+    |> put_change(:emails, new_emails)
+  end
+
   @spec format(t) ::
     t
   @doc """

--- a/lib/story/query/story.ex
+++ b/lib/story/query/story.ex
@@ -28,6 +28,16 @@ defmodule Helix.Story.Query.Story do
   defdelegate get_steps(entity_id),
     to: StepInternal
 
+  @spec fetch_email(Entity.id, Step.contact) ::
+    Story.Email.t
+    | nil
+  @doc """
+  Fetches all emails from a given contact.
+  """
+  defdelegate fetch_email(entity_id, contact_id),
+    to: EmailInternal,
+    as: :fetch
+
   @spec get_emails(Entity.id) ::
     [Story.Email.t]
   @doc """

--- a/lib/story/query/story/setup.ex
+++ b/lib/story/query/story/setup.ex
@@ -1,0 +1,118 @@
+defmodule Helix.Story.Query.Story.Setup do
+  @moduledoc """
+  `StoryQuery.Setup` is a helper tailored for idempotent Step Setups. It should
+  only be used within that context!
+
+  It will check whether the item (:file, :server, :pftp_file, :char, ...) exists
+  *and* is valid within the reasonable step context.
+
+  For instance, a file that is hidden will, by default, return `nil` even if it
+  does exist.
+
+  If the Step wants a more flexible approach (e.g. hidden files are OK, but
+  encrypted ones aren't), the `opts` argument should be used for specificity.
+
+  ### Return format
+
+  In case of failure (object was not found OR object is not deemed valid
+  according to the given `opts`), it should always return `nil`.
+
+  Otherwise, if the object was found, it must return the same format of Make*
+  files, which is:
+
+  {:ok, `item`, `related`, `events`} where:
+
+  - `item` is the object / struct that is being requested
+  - `related` is a map of values related to `item`. Usually it's empty.
+  - `events` is a list of events that should be emitted. Almost always it's an
+    empty list.
+  """
+
+  import Helix.Story.Model.Step.Macros.Setup
+
+  alias Helix.Entity.Model.Entity
+  alias Helix.Entity.Query.Entity, as: EntityQuery
+  alias Helix.Server.Model.Server
+  alias Helix.Server.Query.Server, as: ServerQuery
+  alias Helix.Software.Model.File
+  alias Helix.Software.Model.PublicFTP
+  alias Helix.Software.Query.File, as: FileQuery
+  alias Helix.Software.Query.PublicFTP, as: PublicFTPQuery
+  alias Helix.Story.Model.Step
+  alias Helix.Story.Query.Context, as: ContextQuery
+
+  @typep opts :: list
+
+  @spec find_char({Entity.id, Step.contact_id}, opts) ::
+    {:ok, Server.t, %{entity: Entity.t}, list}
+    | nil
+  @doc """
+  Checks whether the `char` exists.
+
+  - A Context.t must exist for the given {`entity_id`, `contact_id`}
+  - The contact's server must exist
+  - The contact's entity must exist
+  """
+  find :char, {entity_id = %Entity.ID{}, contact_id} do
+    with \
+      context = %{} <- ContextQuery.get(entity_id, contact_id),
+      server = %{} <- ServerQuery.fetch(context.server_id),
+      entity = %{} <- EntityQuery.fetch(context.entity_id)
+    do
+      {:ok, server, %{entity: entity}, []}
+    end
+  end
+
+  @spec find_file(File.idt, opts) ::
+    {:ok, File.t, %{}, list}
+    | nil
+  @doc """
+  Checks whether the `file` exists
+
+  - File must exist
+  - File must not be hidden (NOTYET)
+  - File must not be encrypted (NOTYET)
+  """
+  find :file, %File{}, get: :file_id
+  find :file, file_id = %File.ID{} do
+    with file = %{} <- FileQuery.fetch(file_id) do
+      {:ok, file, %{}, []}
+    end
+  end
+
+  @spec find_pftp_server(Server.idt, opts) ::
+    {:ok, PublicFTP.t, %{}, list}
+    | nil
+  @doc """
+  Checks whether the PublicFTP server exists.
+
+  - PFTPServer must exist for the given server
+  - PFTPServer must be enabled
+  """
+  find :pftp_server, %Server{}, get: :server_id
+  find :pftp_server, server_id = %Server.ID{} do
+    with \
+      pftp = %{} <- PublicFTPQuery.fetch_server(server_id),
+      true <- PublicFTP.is_active?(pftp)
+    do
+      {:ok, pftp, %{}, []}
+    end
+  end
+
+  @spec find_pftp_file(File.idt, opts) ::
+    {:ok, PublicFTP.File.t, %{}, list}
+    | nil
+  @doc """
+  Checks whether the File is added to the PublicFTP Server.
+
+  - PublicFTP Server must exist (indirect check)
+  - PublicFTP Server must be enabled (indirect check)
+  - File must be added to the PublicFTP Server
+  """
+  find :pftp_file, %File{}, get: :file_id
+  find :pftp_file, file_id = %File.ID{} do
+    with pftp_file = %{} <- PublicFTPQuery.fetch_file(file_id) do
+      {:ok, pftp_file, %{}, []}
+    end
+  end
+end

--- a/priv/repo/software/migrations/20180210115107_fix_cascade_relationship_on_pftp_file.exs
+++ b/priv/repo/software/migrations/20180210115107_fix_cascade_relationship_on_pftp_file.exs
@@ -14,7 +14,7 @@ defmodule Helix.Software.Repo.Migrations.FixCascadeRelationshipOnPFTPFile do
       ADD CONSTRAINT pftp_files_file_id_fkey
       FOREIGN KEY (file_id)
       REFERENCES files(file_id)
-      ON DELETE CASCADE;
+      ON DELETE CASCADE
     """
   end
 end

--- a/priv/repo/software/migrations/20180210115107_fix_cascade_relationship_on_pftp_file.exs
+++ b/priv/repo/software/migrations/20180210115107_fix_cascade_relationship_on_pftp_file.exs
@@ -1,0 +1,20 @@
+defmodule Helix.Software.Repo.Migrations.FixCascadeRelationshipOnPFTPFile do
+  use Ecto.Migration
+
+  def change do
+    # Remove old FK
+    execute """
+    ALTER TABLE pftp_files
+      DROP CONSTRAINT pftp_files_file_id_fkey
+    """
+
+    # Add new FK with ON DELETE CASCADE (as opposed to SET NULL)
+    execute """
+    ALTER TABLE pftp_files
+      ADD CONSTRAINT pftp_files_file_id_fkey
+      FOREIGN KEY (file_id)
+      REFERENCES files(file_id)
+      ON DELETE CASCADE;
+    """
+  end
+end

--- a/priv/repo/story/migrations/20180201171652_story_contact.exs
+++ b/priv/repo/story/migrations/20180201171652_story_contact.exs
@@ -23,8 +23,7 @@ defmodule Helix.Story.Repo.Migrations.StoryContact do
       add :emails, {:array, :jsonb}, null: false, default: []
     end
 
-    # Apparently Ecto does not work well with composite FKs
-    # https://elixirforum.com/t/does-ecto-supports-composite-foreign-keys/2466
+    # FK below was removed. See `RemoveStoryEmailsFK` for context
     execute """
     ALTER TABLE story_emails
       ADD CONSTRAINT story_emails_fkey

--- a/priv/repo/story/migrations/20180211060220_remove_story_emails_fk.exs
+++ b/priv/repo/story/migrations/20180211060220_remove_story_emails_fk.exs
@@ -1,0 +1,12 @@
+defmodule Helix.Story.Repo.Migrations.RemoveStoryEmailsFK do
+  use Ecto.Migration
+
+  def change do
+    # Removing the `story_emails` FK because emails are mostly historical, they
+    # still exist even if all steps from a specific contact have been completed
+    execute """
+    ALTER TABLE story_emails
+      DROP CONSTRAINT story_emails_fkey
+    """
+  end
+end

--- a/test/account/websocket/channel/account/topics/email_reply_test.exs
+++ b/test/account/websocket/channel/account/topics/email_reply_test.exs
@@ -94,7 +94,7 @@ defmodule Helix.Account.Websocket.Channel.Account.Topics.EmailReplyTest do
       {socket, %{entity_id: entity_id}} = ChannelSetup.join_account()
 
       # Remove any existing step
-      StoryHelper.remove_existing_step(entity_id)
+      StoryHelper.remove_existing_steps(entity_id)
 
       params =
         %{

--- a/test/features/storyline/flow_test.exs
+++ b/test/features/storyline/flow_test.exs
@@ -14,6 +14,7 @@ defmodule Helix.Test.Features.Storyline.Flow do
   alias Helix.Test.Entity.Helper, as: EntityHelper
   alias Helix.Test.Process.TOPHelper
   alias Helix.Test.Server.Helper, as: ServerHelper
+  alias Helix.Test.Story.Vars, as: StoryVars
 
   @moduletag :feature
 
@@ -30,15 +31,33 @@ defmodule Helix.Test.Features.Storyline.Flow do
           account_id: account.account_id, socket: server_socket
         )
 
+      # Inherit storyline variables
+      s = StoryVars.vars()
+
       # Player is on mission
       assert [%{object: cur_step}] = StoryQuery.get_steps(entity_id)
       assert cur_step.name == Step.first_step_name()
 
-      # We'll now complete the first step by replying to the email
+      # We'll now progress on the first step by replying to the email
       params =
         %{
-          "reply_id" => "back_thanks",
-          "contact_id" => to_string(cur_step.contact)
+          "reply_id" => s.step.setup_pc.msg2,
+          "contact_id" => s.contact.friend
+        }
+      ref = push account_socket, "email.reply", params
+      assert_reply ref, :ok, _, timeout()
+
+      # Contact just replied with the next message
+      [story_email_sent] = wait_events [:story_email_sent]
+
+      assert_email \
+        story_email_sent, s.step.setup_pc.msg3, s.step.setup_pc.msg4, cur_step
+
+      # Now we'll reply back and finally proceed to the next step
+      params =
+        %{
+          "reply_id" => s.step.setup_pc.msg4,
+          "contact_id" => s.contact.friend
         }
       ref = push account_socket, "email.reply", params
       assert_reply ref, :ok, _, timeout(:slow)
@@ -46,7 +65,8 @@ defmodule Helix.Test.Features.Storyline.Flow do
       # Now we've proceeded to the next step.
       [story_step_proceeded] = wait_events [:story_step_proceeded]
 
-      assert_transition story_step_proceeded, "setup_pc", "download_cracker"
+      assert_transition \
+        story_step_proceeded, s.step.setup_pc.name, s.step.setup_pc.next
 
       # Fetch setup data
       %{object: cur_step} = StoryQuery.fetch_step(entity_id, cur_step.contact)
@@ -75,7 +95,7 @@ defmodule Helix.Test.Features.Storyline.Flow do
       [story_step_proceeded] = wait_events [:story_step_proceeded]
 
       assert_transition \
-        story_step_proceeded, "download_cracker", "download_cracker"
+        story_step_proceeded, "download_cracker", s.step.setup_pc.name
     end
   end
 end

--- a/test/features/storyline/quests/tutorial_test.exs
+++ b/test/features/storyline/quests/tutorial_test.exs
@@ -1,4 +1,4 @@
-defmodule Helix.Test.Features.Storyline.Flow do
+defmodule Helix.Test.Features.Storyline.Quests.Tutorial do
 
   use Helix.Test.Case.Integration
 

--- a/test/features/storyline/restart_test.exs
+++ b/test/features/storyline/restart_test.exs
@@ -1,0 +1,95 @@
+defmodule Helix.Test.Features.Storyline.Restart do
+
+  use Helix.Test.Case.Integration
+
+  import Helix.Test.Channel.Macros
+
+  alias Helix.Software.Internal.File, as: FileInternal
+  alias Helix.Story.Query.Story, as: StoryQuery
+
+  alias Helix.Test.Event.Helper, as: EventHelper
+  alias Helix.Test.Event.Setup, as: EventSetup
+  alias Helix.Test.Channel.Setup, as: ChannelSetup
+  alias Helix.Test.Entity.Helper, as: EntityHelper
+  alias Helix.Test.Story.Helper, as: StoryHelper
+
+  @moduletag :feature
+
+  describe "restart" do
+    test "flow" do
+      {server_socket, %{account: account}} =
+        ChannelSetup.join_storyline_server()
+
+      entity = EntityHelper.fetch_entity_from_account(account)
+      entity_id = entity.entity_id
+
+      # Subscribe for events
+      ChannelSetup.join_account(
+        account_id: account.account_id, socket: server_socket
+      )
+
+      # Player is on mission
+      [%{entry: story_step}] = StoryQuery.get_steps(entity_id)
+
+      # Magically proceed to the next step (DownloadCracker) by replying to the
+      # first one (SetupPC) twice
+      StoryHelper.reply(story_step)
+      StoryHelper.reply(story_step)
+
+      [%{entry: story_step, object: step}] = StoryQuery.get_steps(entity_id)
+
+      # We are on DownloadCracker
+      assert step.name == :tutorial@download_cracker
+
+      # We've the email received `download_cracker1`
+      assert story_step.emails_sent == ["download_cracker1"]
+
+      # 5 emails: 2e + 2r from prev step + "download_cracker1"
+      story_email = StoryQuery.fetch_email(entity_id, step.contact)
+      assert length(story_email.emails) == 5
+      [_, _, _, _, email] = story_email.emails
+
+      assert email.meta["ip"] == step.meta.ip
+
+      # Now we'll be nasty and delete the cracker...
+      step.meta.cracker_id
+      |> FileInternal.fetch()
+      |> FileInternal.delete()
+
+      # And notify the user...
+      step.meta.cracker_id
+      |> EventSetup.Software.file_deleted(step.meta.server_id)
+      |> EventHelper.emit()
+
+      [story_step_restarted] = wait_events [:story_step_restarted]
+
+      # The client received the notification about the new step
+      assert story_step_restarted.data.reason == "file_deleted"
+      assert story_step_restarted.data.checkpoint == "download_cracker1"
+      assert story_step_restarted.data.step == to_string(step.name)
+      assert story_step_restarted.data.meta.ip == step.meta.ip
+      assert story_step_restarted.data.allowed_replies
+
+      # By querying directly on the DB, the data has been updated as well
+      [%{object: new_step}] = StoryQuery.get_steps(entity_id)
+
+      # `cracker_id` has changed (it was regenerated)
+      refute new_step.meta.cracker_id == step.meta.cracker_id
+
+      # But the unchanged data is the same
+      assert new_step.meta.server_id == step.meta.server_id
+      assert new_step.meta.ip == step.meta.ip
+
+      # Still 5 emails...
+      story_email = StoryQuery.fetch_email(entity_id, step.contact)
+      assert length(story_email.emails) == 5
+      [_, _, _, _, new_email] = story_email.emails
+
+      assert new_email.meta["ip"] == step.meta.ip
+
+      # Yet, even though both `email` and `new_email` have the same meta and ID,
+      # they are not the same (different timestamps)
+      refute new_email == email
+    end
+  end
+end

--- a/test/story/model/macro_test.exs
+++ b/test/story/model/macro_test.exs
@@ -65,7 +65,7 @@ defmodule Helix.Story.Model.MacroTest do
       )
 
       # Generate for the first time (100% misses)
-      assert {meta, _, _events} = Steppable.setup(step, %{})
+      assert {meta, _, _events} = Steppable.setup(step)
 
       assert meta.cracker_id
       assert meta.server_id
@@ -73,7 +73,7 @@ defmodule Helix.Story.Model.MacroTest do
 
       # Try again, now redoing everything (for idempotency, should be 100% hits)
       step = %{step| meta: meta}
-      assert {meta2, _, _events} = Steppable.setup(step, %{})
+      assert {meta2, _, _events} = Steppable.setup(step)
       assert meta2 == meta
 
       # Now we'll nuke the `cracker_id`.
@@ -83,7 +83,7 @@ defmodule Helix.Story.Model.MacroTest do
 
       # As a result, a new `cracker_id` should be generated, but everything else
       # should be the same
-      assert {meta3, _, _events} = Steppable.setup(step, %{})
+      assert {meta3, _, _events} = Steppable.setup(step)
 
       # New cracker was generated
       refute meta3.cracker_id == meta.cracker_id

--- a/test/story/quests/tutorial_test.exs
+++ b/test/story/quests/tutorial_test.exs
@@ -1,0 +1,31 @@
+defmodule Helix.Story.Quests.Tutorial.DownloadCrackerTest do
+
+  use Helix.Test.Case.Integration
+
+  alias Helix.Story.Model.Steppable
+
+  alias Helix.Test.Server.Setup, as: ServerSetup
+  alias Helix.Test.Story.Helper, as: StoryHelper
+  alias Helix.Test.Story.Setup, as: StorySetup
+
+  describe "setup/2" do
+    test "creates the context/environment; idempotent" do
+      {step, _} = StorySetup.step(
+        name: :tutorial@download_cracker,
+        meta: %{},
+        ready: true
+      )
+
+      assert {meta, _, _events} = Steppable.setup(step, %{})
+
+      assert meta.server_id
+      assert meta.cracker_id
+      assert meta.ip
+
+      # Ensure idempotency
+      step = %{step| meta: meta}
+      assert {meta2, _, _events} = Steppable.setup(step, %{})
+      assert meta2 == meta
+    end
+  end
+end

--- a/test/story/quests/tutorial_test.exs
+++ b/test/story/quests/tutorial_test.exs
@@ -4,19 +4,15 @@ defmodule Helix.Story.Quests.Tutorial.DownloadCrackerTest do
 
   alias Helix.Story.Model.Steppable
 
-  alias Helix.Test.Server.Setup, as: ServerSetup
-  alias Helix.Test.Story.Helper, as: StoryHelper
   alias Helix.Test.Story.Setup, as: StorySetup
 
-  describe "setup/2" do
+  describe "setup/1" do
     test "creates the context/environment; idempotent" do
       {step, _} = StorySetup.step(
-        name: :tutorial@download_cracker,
-        meta: %{},
-        ready: true
+        name: :tutorial@download_cracker, meta: %{}, ready: true
       )
 
-      assert {meta, _, _events} = Steppable.setup(step, %{})
+      assert {meta, _, _events} = Steppable.setup(step)
 
       assert meta.server_id
       assert meta.cracker_id
@@ -24,8 +20,14 @@ defmodule Helix.Story.Quests.Tutorial.DownloadCrackerTest do
 
       # Ensure idempotency
       step = %{step| meta: meta}
-      assert {meta2, _, _events} = Steppable.setup(step, %{})
+      assert {meta2, _, _events} = Steppable.setup(step)
       assert meta2 == meta
     end
+  end
+
+  describe "callbacks" do
+    # Tested on `StoryHandlerTest`
+    # test "on_file_deleted" do
+    # end
   end
 end

--- a/test/support/channel/macros.ex
+++ b/test/support/channel/macros.ex
@@ -56,9 +56,9 @@ defmodule Helix.Test.Channel.Macros do
   @doc """
   Debugger/helper that lists all events in the mailbox.
   """
-  defmacro list_events do
+  defmacro list_events(timeout \\ quote(do: 50)) do
     quote do
-      unquote(wait_all())
+      unquote(wait_all(timeout))
     end
   end
 end

--- a/test/support/event/setup/software.ex
+++ b/test/support/event/setup/software.ex
@@ -7,7 +7,9 @@ defmodule Helix.Test.Event.Setup.Software do
   alias Helix.Server.Model.Server
   alias Helix.Software.Internal.File, as: FileInternal
   alias Helix.Software.Internal.Storage, as: StorageInternal
+  alias Helix.Software.Model.File
 
+  alias Helix.Software.Event.File.Deleted, as: FileDeletedEvent
   alias Helix.Software.Event.File.Downloaded, as: FileDownloadedEvent
   alias Helix.Software.Event.File.DownloadFailed, as: FileDownloadFailedEvent
   alias Helix.Software.Event.File.Install.Processed,
@@ -57,6 +59,12 @@ defmodule Helix.Test.Event.Setup.Software do
       target_server_ip: Random.ipv4()
     }
   end
+
+  @doc """
+  Generates a FileDeletedEvent
+  """
+  def file_deleted(file_id = %File.ID{}, server_id = %Server.ID{}),
+    do: FileDeletedEvent.new(file_id, server_id)
 
   @doc """
   Generates a FileDownloaded event with real data.

--- a/test/support/story/fake_steps.ex
+++ b/test/support/story/fake_steps.ex
@@ -46,7 +46,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     empty_setup()
 
-    def start(step, _),
+    def start(step),
       do: {:ok, step, []}
 
     def complete(step),
@@ -73,7 +73,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     empty_setup()
 
-    def start(step, _),
+    def start(step),
       do: {:ok, step, []}
 
     def complete(step),
@@ -86,7 +86,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     empty_setup()
 
-    def start(step, _),
+    def start(step),
       do: {:ok, step, []}
 
     def complete(step),
@@ -102,7 +102,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     empty_setup()
 
-    def start(step, _),
+    def start(step),
       do: {:ok, step, []}
 
     def complete(step),
@@ -118,7 +118,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     empty_setup()
 
-    def start(step, _),
+    def start(step),
       do: {:ok, step, []}
 
     def complete(step),
@@ -156,7 +156,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     empty_setup()
 
-    def start(step, _) do
+    def start(step) do
       send_email step, "e1"
       {:ok, step, []}
     end
@@ -165,6 +165,39 @@ defmodule Helix.Story.Mission.FakeSteps do
       do: {:ok, step, []}
 
     next_step Helix.Story.Mission.FakeSteps.TestSimple
+  end
+
+  step TestMsgFlow do
+
+    email "e1",
+      reply: ["reply_to_e1"]
+
+    on_reply "reply_to_e1",
+      send: "e2"
+
+    email "e2",
+      reply: ["reply_to_e2"]
+
+    on_reply "reply_to_e2",
+      send: "e3"
+
+    email "e3",
+      reply: ["reply_to_e3"]
+
+    on_reply "reply_to_e3",
+      :complete
+
+    empty_setup()
+
+    def start(step) do
+      send_email step, "e1"
+      {:ok, step, []}
+    end
+
+    def complete(step),
+      do: {:ok, step, []}
+
+    next_step __MODULE__
   end
 end
 
@@ -178,7 +211,7 @@ defmodule Helix.Story.Mission.FakeContactOne do
 
     empty_setup()
 
-    def start(step, _),
+    def start(step),
       do: {:ok, step, []}
 
     def complete(step),
@@ -198,7 +231,7 @@ defmodule Helix.Story.Mission.FakeContactTwo do
 
     empty_setup()
 
-    def start(step, _),
+    def start(step),
       do: {:ok, step, []}
 
     def complete(step),

--- a/test/support/story/fake_steps.ex
+++ b/test/support/story/fake_steps.ex
@@ -44,7 +44,9 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     alias Helix.Entity.Model.Entity
 
-    def setup(step, _),
+    empty_setup()
+
+    def start(step, _),
       do: {:ok, step, []}
 
     def complete(step),
@@ -68,15 +70,23 @@ defmodule Helix.Story.Mission.FakeSteps do
   end
 
   step TestSimple do
-    def setup(step, _),
+
+    empty_setup()
+
+    def start(step, _),
       do: {:ok, step, []}
+
     def complete(step),
       do: {:ok, step, []}
+
     next_step __MODULE__
   end
 
   step TestOne do
-    def setup(step, _),
+
+    empty_setup()
+
+    def start(step, _),
       do: {:ok, step, []}
 
     def complete(step),
@@ -89,7 +99,10 @@ defmodule Helix.Story.Mission.FakeSteps do
   end
 
   step TestTwo do
-    def setup(step, _),
+
+    empty_setup()
+
+    def start(step, _),
       do: {:ok, step, []}
 
     def complete(step),
@@ -102,7 +115,10 @@ defmodule Helix.Story.Mission.FakeSteps do
   end
 
   step TestCounter do
-    def setup(step, _),
+
+    empty_setup()
+
+    def start(step, _),
       do: {:ok, step, []}
 
     def complete(step),
@@ -138,7 +154,9 @@ defmodule Helix.Story.Mission.FakeSteps do
     on_reply "reply_to_e3",
       :complete
 
-    def setup(step, _) do
+    empty_setup()
+
+    def start(step, _) do
       send_email step, "e1"
       {:ok, step, []}
     end
@@ -157,10 +175,15 @@ defmodule Helix.Story.Mission.FakeContactOne do
   contact :contact_one
 
   step TestSimple do
-    def setup(step, _),
+
+    empty_setup()
+
+    def start(step, _),
       do: {:ok, step, []}
+
     def complete(step),
       do: {:ok, step, []}
+
     next_step __MODULE__
   end
 end
@@ -172,10 +195,15 @@ defmodule Helix.Story.Mission.FakeContactTwo do
   contact :contact_two
 
   step TestSimple do
-    def setup(step, _),
+
+    empty_setup()
+
+    def start(step, _),
       do: {:ok, step, []}
-      def complete(step),
-        do: {:ok, step, []}
-      next_step __MODULE__
+
+    def complete(step),
+      do: {:ok, step, []}
+
+    next_step __MODULE__
   end
 end

--- a/test/support/story/helper.ex
+++ b/test/support/story/helper.ex
@@ -4,7 +4,7 @@ defmodule Helix.Test.Story.Helper do
   alias Helix.Story.Model.Story
   alias Helix.Story.Repo, as: StoryRepo
 
-  def remove_existing_step(entity_id) do
+  def remove_existing_steps(entity_id) do
     entity_id
     |> StepInternal.get_steps()
     |> Enum.each(&(StoryRepo.delete(&1.entry)))

--- a/test/support/story/helper.ex
+++ b/test/support/story/helper.ex
@@ -29,22 +29,6 @@ defmodule Helix.Test.Story.Helper do
   end
 
   @doc """
-  Generates random contact id
-  """
-  def contact_id do
-    # Guaranteed to be random
-    :friend
-  end
-
-  @doc """
-  Generates random reply id
-  """
-  def reply_id do
-    # Guaranteed to be random
-    "reply_id"
-  end
-
-  @doc """
   Automagically replies to a step.
 
   It randomly selects the `reply_id` from the `allowed_replies` on the given
@@ -91,5 +75,21 @@ defmodule Helix.Test.Story.Helper do
     do
       {:ok, next_step}
     end
+  end
+
+  @doc """
+  Generates random contact id
+  """
+  def contact_id do
+    # Guaranteed to be random
+    :friend
+  end
+
+  @doc """
+  Generates random reply id
+  """
+  def reply_id do
+    # Guaranteed to be random
+    "reply_id"
   end
 end

--- a/test/support/story/helper.ex
+++ b/test/support/story/helper.ex
@@ -1,7 +1,13 @@
 defmodule Helix.Test.Story.Helper do
 
+  alias Helix.Event
+  alias Helix.Story.Action.Story, as: StoryAction
+  alias Helix.Story.Action.Flow.Story, as: StoryFlow
   alias Helix.Story.Internal.Step, as: StepInternal
+  alias Helix.Story.Model.Step
+  alias Helix.Story.Model.Steppable
   alias Helix.Story.Model.Story
+  alias Helix.Story.Query.Story, as: StoryQuery
   alias Helix.Story.Repo, as: StoryRepo
 
   def remove_existing_steps(entity_id) do
@@ -36,5 +42,54 @@ defmodule Helix.Test.Story.Helper do
   def reply_id do
     # Guaranteed to be random
     "reply_id"
+  end
+
+  @doc """
+  Automagically replies to a step.
+
+  It randomly selects the `reply_id` from the `allowed_replies` on the given
+  `story_step`. Prone to error in some cases so beware.
+  """
+  def reply(story_step) do
+    # Ensure an up-to-date struct
+    %{entry: story_step} =
+      StoryQuery.fetch_step(story_step.entity_id, story_step.contact_id)
+
+    reply_id = get_allowed_reply(story_step)
+
+    StoryFlow.send_reply(story_step.entity_id, story_step.contact_id, reply_id)
+  end
+
+  @doc """
+  Automagically proceeds to the next step. It detects the next step after `step`
+  and will proceed to that. IT WILL NOT PROCEED TO `step`, BUT TO THE NEXT ONE!
+  """
+  def proceed_step(step) do
+    next_step =
+      step
+      |> Steppable.next_step()
+      |> Step.fetch(step.entity_id, %{}, step.manager)
+
+    remove_existing_steps(step.entity_id)
+
+    start_step(next_step)
+  end
+
+  @doc """
+  Helper to simulate a step being started. It's very similar to `update_next/2`
+  on StoryHandler.
+  """
+  def start_step(step) do
+    with \
+      {:ok, _} <- StoryAction.proceed_step(step),
+
+      {:ok, next_step, events} <- Steppable.start(step),
+      Event.emit(events),
+
+      # Update step meta
+      {:ok, _} <- StoryAction.update_step_meta(next_step)
+    do
+      {:ok, next_step}
+    end
   end
 end

--- a/test/support/story/macros.ex
+++ b/test/support/story/macros.ex
@@ -1,15 +1,42 @@
 defmodule Helix.Test.Story.Macros do
 
+  alias HELL.Utils
+
   @doc """
   Asserts that the story has transitioned from `expected_from` to `expected_to`
   """
   defmacro assert_transition(event, expected_from, expected_to) do
     quote do
+
       event_from = unquote(event).data.previous_step
       event_to = unquote(event).data.next_step
 
       assert String.contains?(event_from, unquote(expected_from))
       assert String.contains?(event_to, unquote(expected_to))
+
+    end
+  end
+
+  @doc """
+  Asserts that the received email is the one expected, including the allowed
+  replies and the contact/step are the same as before.
+  """
+  defmacro assert_email(event, expected_email, replies, step) do
+    quote do
+
+      event_data = unquote(event).data
+      replies = Utils.ensure_list(unquote(replies))
+
+      assert unquote(event).event == "story_email_sent"
+      assert event_data.email_id == unquote(expected_email)
+
+      Enum.each(replies, fn reply ->
+        assert Enum.member?(event_data.replies, reply)
+      end)
+
+      assert to_string(unquote(step).contact) == event_data.contact_id
+      assert to_string(unquote(step).name) == event_data.step
+
     end
   end
 end

--- a/test/support/story/setup/manager.ex
+++ b/test/support/story/setup/manager.ex
@@ -6,6 +6,7 @@ defmodule Helix.Test.Story.Setup.Manager do
 
   alias Helix.Test.Entity.Setup, as: EntitySetup
   alias Helix.Test.Network.Helper, as: NetworkHelper
+  alias Helix.Test.Network.Setup, as: NetworkSetup
   alias Helix.Test.Server.Setup, as: ServerSetup
 
   @doc """
@@ -17,15 +18,33 @@ defmodule Helix.Test.Story.Setup.Manager do
     {inserted, related}
   end
 
+  def manager!(opts \\ []) do
+    {manager, _} = manager(opts)
+    manager
+  end
+
   @doc """
   - entity_id: Set entity whose Manager belongs to. Defaults to fake entity
   - server_id: Set server ID. Defaults to fake server
   - network_id: Set network ID. Defaults to fake network.
+  - real_network: Whether to use a real network. Defaults to false.
   """
   def fake_manager(opts \\ []) do
     entity_id = Keyword.get(opts, :entity_id, EntitySetup.id())
     server_id = Keyword.get(opts, :server_id, ServerSetup.id())
-    network_id = Keyword.get(opts, :network_id, NetworkHelper.id())
+
+    network_id =
+      cond do
+        opts[:real_network] ->
+          {network, _} = NetworkSetup.network(type: :story)
+          network.network_id
+
+        opts[:network_id] ->
+          opts[:network_id]
+
+        true ->
+          NetworkHelper.id()
+      end
 
     manager =
       %Story.Manager{

--- a/test/support/story/vars.ex
+++ b/test/support/story/vars.ex
@@ -1,6 +1,7 @@
 defmodule Helix.Test.Story.Vars do
   @moduledoc """
-  This helper will inject (in a non-higienic way!)
+  This helper holds storyline-wide IDs and pointers. Helpful to avoiding
+  hard-coding stuff on the tests!
   """
 
   @vars %{

--- a/test/support/story/vars.ex
+++ b/test/support/story/vars.ex
@@ -1,0 +1,24 @@
+defmodule Helix.Test.Story.Vars do
+  @moduledoc """
+  This helper will inject (in a non-higienic way!)
+  """
+
+  @vars %{
+    contact: %{
+      friend: "friend"
+    },
+    step: %{
+      setup_pc: %{
+        name: "setup_pc",
+        next: "download_cracker",
+        msg1: "welcome",
+        msg2: "back_thanks",
+        msg3: "watchiadoing",
+        msg4: "hell_yeah",
+      }
+    }
+  }
+
+  def vars,
+    do: @vars
+end


### PR DESCRIPTION
Closes #333. Closes #274.

Now you *can* delete your cracker and still proceed with the tutorial! :tada: 

#### TODO:

- [x] Internal refactor for reuse of `Steppable.setup` (made it idempotent)
- [x] `StepRestartedEvent`
- [x] Rollback emails / messages on checkpoint defined at StepRestartedEvent
- [x] Docs (marked as DOCME)
- [x] Specs missing at SetupStory
- [x] Update `Story.Step` meta when data has been regenerated

#### Notes

-  ~~Unlike `Steppable.start`, `Steppable.restart` seems generic (it does not change for each step) and as such can be abstracted into a single function, so *I think* there's no need to implement it on each Step declaration.~~
Due to a tiny detail (checkpoint (email) metadata is defined on the restart method), this cannot be done. A refactor where we make the whole Step interface 100% declarative would solve this, but there's no time for that.

#### Incidental

- Renamed `Steppable.fail` to `Steppable.restart`. Failure no longer exists :raised_hands:.
- Split old `Steppable.setup/1` into two parts, `Steppable.start/1` and `Steppable.setup/1`. Now the setup only does the setup, and is reused at `Steppable.restart`.
- `Steppable.setup/1` must be idempotent, so existing code was updated.
-  `setup_once` macro to quickly enable idempotent object search/creation at `Steppable.setup`
- Added `FileDeletedEvent`. Proper handlers on `FilesystemHandlers` are missing.
- `StoryQuery.Setup` for standardized idempotency search during `Steppable.setup`
- Removed FK on `story_emails`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/383)
<!-- Reviewable:end -->
