### PR TITLE
DownloadCracker tutorial step

### DIFF
--- a/events.json
+++ b/events.json
@@ -113,7 +113,11 @@
       "emits": ["Steppable (custom)"]
     },
     "Story.Story": {
-      "receives": ["All"],
+      "receives": [
+        "Story.Step.Email.Sent",
+        "Story.Step.Reply.Sent",
+        "Story.Step.ActionRequested"
+      ],
       "emits": [
         "Story.Step.Proceeded",
         "Story.Step.Restarted",

--- a/lib/core/listener/event/handler/listener.ex
+++ b/lib/core/listener/event/handler/listener.ex
@@ -17,6 +17,11 @@ defmodule Helix.Core.Listener.Event.Handler.Listener do
   services subscribed to that specific event under that specific object ID.
   """
   def listener_handler(event) do
+    # OPTMIZE: There's room for optimization on this function. Some events may
+    # return several objects on `Listenable.get_objects/0`, and currently we
+    # perform a separate query for each one. Instead, fetching all matching
+    # objects with `IN`, and filtering by `event.__struct__` within the
+    # application would yield a faster operation.
     if Listenable.impl_for(event) do
       event
       |> Listenable.get_objects()
@@ -24,7 +29,7 @@ defmodule Helix.Core.Listener.Event.Handler.Listener do
     end
   end
 
-  @spec find_listeners(term | Listener.object_id, Event.t) ::
+  @spec find_listeners(Listener.object_id, Event.t) ::
     term
   defp find_listeners(object_id, event) do
     object_id

--- a/lib/core/listener/event/handler/listener.ex
+++ b/lib/core/listener/event/handler/listener.ex
@@ -17,7 +17,7 @@ defmodule Helix.Core.Listener.Event.Handler.Listener do
   services subscribed to that specific event under that specific object ID.
   """
   def listener_handler(event) do
-    # OPTMIZE: There's room for optimization on this function. Some events may
+    # OPTIMIZE: There's room for optimization on this function. Some events may
     # return several objects on `Listenable.get_objects/0`, and currently we
     # perform a separate query for each one. Instead, fetching all matching
     # objects with `IN`, and filtering by `event.__struct__` within the

--- a/lib/core/listener/listener.ex
+++ b/lib/core/listener/listener.ex
@@ -2,6 +2,17 @@ defmodule Helix.Core.Listener do
   @moduledoc """
   Main interface to be used by any service that would like to listen/unlisten to
   events happening a specific `object_id`.
+
+  I'm a Listener
+
+    And then I saw her face
+    Now I'm a listener
+    Not a trace
+    Of doubt in my mind
+    I'm in love
+    I'm a listener
+    I couldn't leave her
+    If I tried
   """
 
   import HELL.Macros

--- a/lib/core/listener/model/listener.ex
+++ b/lib/core/listener/model/listener.ex
@@ -104,6 +104,7 @@ defmodule Helix.Core.Listener.Model.Listener do
       meta: meta
     }
   end
+  # TODO: Atomize keys
 
   defmodule Query do
 

--- a/lib/core/listener/model/listener.ex
+++ b/lib/core/listener/model/listener.ex
@@ -6,6 +6,7 @@ defmodule Helix.Core.Listener.Model.Listener do
 
   alias Ecto.Changeset
   alias HELL.HETypes
+  alias HELL.MapUtils
 
   @type t :: %__MODULE__{
     listener_id: id,
@@ -62,6 +63,10 @@ defmodule Helix.Core.Listener.Model.Listener do
   @typedoc """
   `meta` is an additional parameter, defined at "listen-time", which will be
   relayed to the callback once the Listener is triggered.
+
+  For ease of use, we make sure the *keys* are atomized, so:
+  1) It's the callback's responsibility to handle alien values.
+  2) The callback must not use arbitrary meta keys for security reasons.
   """
   @type meta :: map
 
@@ -97,14 +102,18 @@ defmodule Helix.Core.Listener.Model.Listener do
 
   @spec format([term]) ::
     info
+  @doc """
+  Formats the `Listener.t` into the public `Listener.info` type.
+
+  Notice that the `Listener.meta` has its *keys* atomized.
+  """
   def format([[module, method], meta]) do
     %{
       module: module,
       method: method,
-      meta: meta
+      meta: MapUtils.atomize_keys(meta)
     }
   end
-  # TODO: Atomize keys
 
   defmodule Query do
 

--- a/lib/event/dispatcher.ex
+++ b/lib/event/dispatcher.ex
@@ -239,6 +239,10 @@ defmodule Helix.Event.Dispatcher do
   event StoryEvent.Step.Restarted
 
   # Custom handlers
+  event StoryEvent.Email.Sent,
+    StoryHandler.Story,
+    :event_handler
+
   event StoryEvent.Reply.Sent,
     StoryHandler.Story,
     :event_handler

--- a/lib/event/event.ex
+++ b/lib/event/event.ex
@@ -112,7 +112,7 @@ defmodule Helix.Event do
     log_event(event)
   end
 
-  @spec emit_after([t] | t, interval :: float | non_neg_integer) ::
+  @spec emit_after([t] | t, interval :: float | non_neg_integer, from: t) ::
     term
   @doc """
   Emits the given event(s) after `interval` milliseconds have passed.

--- a/lib/event/event.ex
+++ b/lib/event/event.ex
@@ -116,6 +116,23 @@ defmodule Helix.Event do
     term
   @doc """
   Emits the given event(s) after `interval` milliseconds have passed.
+
+  It also inherits data from the source event passed on the `from` parameter.
+  """
+  def emit_after([], _, from: _),
+    do: :noop
+  def emit_after(events = [_|_], interval, from: source_event),
+    do: Enum.each(events, &(emit_after(&1, interval, from: source_event)))
+  def emit_after(event, interval, from: source_event) do
+    event
+    |> inherit(source_event)
+    |> emit_after(interval)
+  end
+
+  @spec emit_after([t] | t, interval :: float | non_neg_integer) ::
+    term
+  @doc """
+  Emits the given event(s) after `interval` milliseconds have passed.
   """
   def emit_after([], _),
     do: :noop

--- a/lib/event/listenable/flow.ex
+++ b/lib/event/listenable/flow.ex
@@ -20,17 +20,43 @@ defmodule Helix.Event.Listenable.Flow do
   `ListenerHandler`.
   """
 
-  defmacro listenable(event, do: block) do
+  @doc """
+  The `listeneable` macro must be used alongside at least one `listen/2`.
+
+  ## Example
+
+  listenable do
+    listen(event = %_{valid?: true}) do
+      [event.entity_id, event.file_id]
+    end
+  end
+  """
+  defmacro listenable(do: block) do
     quote do
 
       defimpl Helix.Event.Listenable do
         @moduledoc false
 
-        @doc false
-        def get_objects(unquote(event)) do
-          unquote(block)
-        end
+        unquote(block)
       end
+
+    end
+  end
+
+  @doc """
+  Expands the expected methods of the `Listenable` protocol.
+  """
+  defmacro listen(event, do: block) do
+    quote do
+
+      @doc false
+      def get_objects(unquote(event)) do
+        unquote(block)
+      end
+
+      # Fallback
+      def get_objects(_),
+        do: []
 
     end
   end

--- a/lib/hell/hack.ex
+++ b/lib/hell/hack.ex
@@ -60,8 +60,9 @@ defmodule HELL.Hack.Experience do
         {:restart, 3},
         {:next_step, 1},
         {:get_contact, 1},
+        {:get_emails, 1},
+        {:get_replies_of, 2},
         {:format_meta, 1},
-        {:get_replies, 2}
       ],
       "Elixir.Helix.Event.Listenable" => [
         {:get_objects, 1}

--- a/lib/process/event/process.ex
+++ b/lib/process/event/process.ex
@@ -118,6 +118,12 @@ defmodule Helix.Process.Event.Process do
       def whom_to_notify(event),
         do: %{server: [event.gateway_id, event.target_id]}
     end
+
+    listenable do
+      listen(event = %_{confirmed: true}) do
+        [event.process.src_file_id, event.process.tgt_file_id]
+      end
+    end
   end
 
   event Completed do

--- a/lib/software/event/file.ex
+++ b/lib/software/event/file.ex
@@ -95,8 +95,10 @@ defmodule Helix.Software.Event.File do
         do: %{server: [event.server_id]}
     end
 
-    listenable(event) do
-      [event.file_id]
+    listenable do
+      listen(event) do
+        [event.file_id]
+      end
     end
   end
 
@@ -234,8 +236,10 @@ defmodule Helix.Software.Event.File do
       end
     end
 
-    listenable(event) do
-      [event.source_file_id]
+    listenable do
+      listen(event) do
+        [event.source_file_id]
+      end
     end
   end
 

--- a/lib/software/process/file/transfer.ex
+++ b/lib/software/process/file/transfer.ex
@@ -215,7 +215,6 @@ process Helix.Software.Process.File.Transfer do
       }
     end
 
-    # REVIEW: `upload` should use a `source_file`, no?
     target_file(_gateway, _target, _params, %{file: file}) do
       file.file_id
     end

--- a/lib/software/process/file/transfer.ex
+++ b/lib/software/process/file/transfer.ex
@@ -215,6 +215,7 @@ process Helix.Software.Process.File.Transfer do
       }
     end
 
+    # REVIEW: `upload` should use a `source_file`, no?
     target_file(_gateway, _target, _params, %{file: file}) do
       file.file_id
     end

--- a/lib/story/action/flow/story.ex
+++ b/lib/story/action/flow/story.ex
@@ -30,7 +30,7 @@ defmodule Helix.Story.Action.Flow.Story do
       with \
         {:ok, _} <- ContextFlow.setup(entity),
         {:ok, story_step} <- StoryAction.proceed_step(first_step),
-        {:ok, _, events} <- Steppable.start(first_step),
+        {:ok, _, events, _} <- Steppable.start(first_step),
         on_success(fn -> Event.emit(events, from: relay) end)
       do
         {:ok, story_step}

--- a/lib/story/event/email.ex
+++ b/lib/story/event/email.ex
@@ -4,7 +4,7 @@ defmodule Helix.Story.Event.Email do
 
   event Sent do
     @moduledoc """
-    Story.EmailSentEvent is fired when a Contact (Storyline character) sends an
+    `StoryEmailSentEvent` is fired when a Contact (Storyline character) sends an
     email to the Player.
     """
 
@@ -34,7 +34,7 @@ defmodule Helix.Story.Event.Email do
     notify do
       @moduledoc """
       Logic of the notification that will be sent to the client once the event
-      `Story.EmailSent` is fired.
+      `StoryEmailSentEvent` is fired.
       """
 
       alias HELL.ClientUtils
@@ -45,7 +45,7 @@ defmodule Helix.Story.Event.Email do
         contact_id = Step.get_contact(event.step) |> to_string()
         replies =
           event.step
-          |> Step.get_replies(event.email.id)
+          |> Step.get_replies_of(event.email.id)
           |> Enum.map(&to_string/1)
 
         data = %{

--- a/lib/story/event/handler/story.ex
+++ b/lib/story/event/handler/story.ex
@@ -121,6 +121,11 @@ defmodule Helix.Story.Event.Handler.Story do
     end
   end
 
+  docp """
+  The requested action may be to send an email, which is handled here.
+
+  This action does not use or depends on `Steppable`.
+  """
   defp handle_action({:send_email, email_id, meta, opts}, step, _story_step) do
     with {:ok, events} <- StoryAction.send_email(step, email_id, meta) do
       emit(events, opts, from: step.event)
@@ -129,6 +134,11 @@ defmodule Helix.Story.Event.Handler.Story do
     end
   end
 
+  docp """
+  The requested action may be to send a reply, which is handled here.
+
+  This action does not use or depends on `Steppable`.
+  """
   defp handle_action({:send_reply, reply_id, opts}, step, story_step) do
     with {:ok, events} <- StoryAction.send_reply(step, story_step, reply_id) do
       emit(events, opts, from: step.event)
@@ -205,6 +215,10 @@ defmodule Helix.Story.Event.Handler.Story do
     end
   end
 
+  docp """
+  Helper that interprets the emission parameters defined at `send_opts` (if any)
+  and makes sure they are followed.
+  """
   defp emit(event, from: source_event),
     do: emit(event, [], from: source_event)
   defp emit(event, [], from: source_event),

--- a/lib/story/event/reply.ex
+++ b/lib/story/event/reply.ex
@@ -41,11 +41,19 @@ defmodule Helix.Story.Event.Reply do
       @event :story_reply_sent
 
       def generate_payload(event, _socket) do
+        contact_id = Step.get_contact(event.step) |> to_string()
+        replies =
+          event.step
+          |> Step.get_replies_of(event.reply.id)
+          |> Enum.map(&to_string/1)
+
         data = %{
           step: to_string(event.step.name),
+          contact_id: contact_id,
           reply_to: event.reply_to,
           reply_id: event.reply.id,
-          timestamp: ClientUtils.to_timestamp(event.reply.timestamp)
+          replies: replies,
+          timestamp: ClientUtils.to_timestamp(event.reply.timestamp),
         }
 
         {:ok, data}

--- a/lib/story/event/step.ex
+++ b/lib/story/event/step.ex
@@ -94,7 +94,7 @@ defmodule Helix.Story.Event.Step do
       def generate_payload(event, _socket) do
         allowed_replies =
           event.step
-          |> Step.get_replies(event.checkpoint)
+          |> Step.get_replies_of(event.checkpoint)
           |> Enum.map(&to_string/1)
 
         data = %{

--- a/lib/story/internal/email.ex
+++ b/lib/story/internal/email.ex
@@ -48,7 +48,7 @@ defmodule Helix.Story.Internal.Email do
 
   @spec send_email(Step.t, Step.email_id, Step.email_meta) ::
     {:ok, Story.Email.t, Story.Email.email}
-    | :internal_error
+    | {:error, :internal}
   @doc """
   Sends an email from the contact to the player.
   """
@@ -57,7 +57,7 @@ defmodule Helix.Story.Internal.Email do
 
   @spec send_reply(Step.t, Step.reply_id) ::
     {:ok, Story.Email.t, Story.Email.email}
-    | :internal_error
+    | {:error, :internal}
   @doc """
   Sends a reply from the player to the contact.
   """
@@ -78,7 +78,7 @@ defmodule Helix.Story.Internal.Email do
 
   @spec generic_send(term, id :: String.t, Story.Email.sender, meta :: map) ::
     {:ok, Story.Email.t, Story.Email.email}
-    | :internal_error
+    | {:error, :internal}
   defp generic_send(step, id, sender, meta \\ %{}) do
     email = create_email(id, sender, meta)
     contact_id = Step.get_contact(step)
@@ -89,7 +89,7 @@ defmodule Helix.Story.Internal.Email do
         entry = format(story_email)
         {:ok, entry, List.last(entry.emails)}
       _ ->
-        :internal_error
+        {:error, :internal}
     end
   end
 

--- a/lib/story/internal/step.ex
+++ b/lib/story/internal/step.ex
@@ -150,7 +150,7 @@ defmodule Helix.Story.Internal.Step do
   are unlocked by default)
   """
   def save_email(step, email_id) do
-    replies = Step.get_replies(step, email_id)
+    replies = Step.get_replies_of(step, email_id)
 
     step
     |> fetch!()
@@ -164,7 +164,7 @@ defmodule Helix.Story.Internal.Step do
   Rollbacks the Story.Step emails to the specified checkpoint.
   """
   def rollback_email(step, checkpoint) do
-    replies = Step.get_replies(step, checkpoint)
+    replies = Step.get_replies_of(step, checkpoint)
 
     step
     |> fetch!()

--- a/lib/story/mission/tutorial/steps.ex
+++ b/lib/story/mission/tutorial/steps.ex
@@ -16,7 +16,7 @@ defmodule Helix.Story.Mission.Tutorial do
       replies: "hell_yeah"
 
     on_reply "hell_yeah",
-      :complete
+      do: :complete
 
     empty_setup()
 

--- a/lib/story/mission/tutorial/steps.ex
+++ b/lib/story/mission/tutorial/steps.ex
@@ -7,13 +7,13 @@ defmodule Helix.Story.Mission.Tutorial do
   step SetupPc do
 
     email "welcome",
-      reply: "back_thanks"
+      replies: "back_thanks"
 
     on_reply "back_thanks",
       send: "watchiadoing"
 
     email "watchiadoing",
-      reply: "hell_yeah"
+      replies: "hell_yeah"
 
     on_reply "hell_yeah",
       :complete
@@ -23,7 +23,7 @@ defmodule Helix.Story.Mission.Tutorial do
     def start(step) do
       e1 = send_email step, "welcome"
 
-      {:ok, step, e1}
+      {:ok, step, e1, []}
     end
 
     def complete(step) do
@@ -46,16 +46,30 @@ defmodule Helix.Story.Mission.Tutorial do
     alias Helix.Software.Make.File, as: MakeFile
     alias Helix.Software.Make.PFTP, as: MakePFTP
 
-    email "download_cracker1",
-      reply: ["more_info"],
-      locked: ["sure"]
+    email "download_cracker1"
 
-    email "give_more_info",
-      reply: ["sure"],
-      locked: ["more_info"]
+    email "about_that",
+      replies: ["yeah_right"]
 
-    on_reply "more_info",
-      send: "give_more_info"
+    on_email "about_that",
+      reply: "yeah_right",
+      send_opts: [sleep: 2]
+
+    reply "yeah_right",
+      replies: "downloaded"
+
+    reply "downloaded",
+      replies: ["nothing_now"]
+
+    on_reply "downloaded",
+      send: "nothing_now",
+      send_opts: [sleep: 5]
+
+    email "nothing_now"
+
+    on_email "nothing_now",
+      do: :complete,
+      send_opts: [sleep: 3]
 
     def setup(step) do
       # Create the underlying character (@contact) and its server
@@ -80,22 +94,21 @@ defmodule Helix.Story.Mission.Tutorial do
           MakeFile.cracker(server, %{bruteforce: 10, overflow: 10})
         end
 
-      # Enable the PFTP server and put the cracker in it
+      # Enable the PFTP server
       {:ok, pftp, _, e3} =
         setup_once :pftp_server, server do
           MakePFTP.server(server)
         end
 
+      # Make the Cracker available for download on the PFTP server
       {:ok, _, _, e4} =
         setup_once :pftp_file, cracker do
           MakePFTP.add_file(cracker, pftp)
         end
 
-      ip = ServerQuery.get_ip(server, step.manager.network_id)
-
       meta =
         %{
-          ip: ip,
+          ip: ServerQuery.get_ip(server, step.manager.network_id),
           server_id: server.server_id,
           cracker_id: cracker.file_id
         }
@@ -103,15 +116,17 @@ defmodule Helix.Story.Mission.Tutorial do
       # Listeners
       hespawn fn ->
 
-        # React to the moment the cracker is downloaded
-        story_listen cracker.file_id, FileDownloadedEvent, do: :complete
+        # Send `about_that` when download starts
+        on_process_started :file_download, cracker.file_id, email: "about_that"
+
+        # Reply `downloaded` when the cracker has been downloaded
+        story_listen cracker.file_id, FileDownloadedEvent, reply: "downloaded"
 
         story_listen cracker.file_id, FileDeletedEvent, :on_file_deleted
+
       end
 
-      events = e1 ++ e2 ++ e3 ++ e4
-
-      {meta, %{}, events}
+      {meta, %{}, e1 ++ e2 ++ e3 ++ e4}
     end
 
     # Callbacks
@@ -127,7 +142,7 @@ defmodule Helix.Story.Mission.Tutorial do
 
       step = %{step| meta: meta}
 
-      {:ok, step, e1 ++ e2}
+      {:ok, step, e1 ++ e2, sleep: 4}
     end
 
     format_meta do
@@ -148,6 +163,26 @@ defmodule Helix.Story.Mission.Tutorial do
       {:ok, %{step| meta: meta}, %{ip: meta.ip}, e1}
     end
 
-    next_step Helix.Story.Mission.Tutorial.SetupPc
+    next_step Helix.Story.Mission.Tutorial.NastyVirus
+  end
+
+  step NastyVirus do
+
+    email "nasty_virus1"
+
+    empty_setup()
+
+    def start(step) do
+      e1 = send_email step, "nasty_virus1", %{}
+
+      {:ok, step, e1, sleep: 4}
+    end
+
+    def complete(step) do
+      {:ok, step, []}
+    end
+
+    next_step __MODULE__
+
   end
 end

--- a/lib/story/model/step/macros.ex
+++ b/lib/story/model/step/macros.ex
@@ -129,8 +129,8 @@ defmodule Helix.Story.Model.Step.Macros do
           Predefined callback when user asks to `:send_email`. `meta` must
           contain required data, in this case at least `email_id`.
           """
-          callback :cb_send_email, _event, meta = %{"email_id" => email_id} do
-            email_meta = Map.get(meta, "email_meta", %{})
+          callback :cb_send_email, _event, meta = %{email_id: email_id} do
+            email_meta = Map.get(meta, :email_meta, %{})
 
             {{:send_email, email_id, email_meta, []}, []}
           end
@@ -139,7 +139,7 @@ defmodule Helix.Story.Model.Step.Macros do
           Predefined callback when user asks to `:send_reply`. `meta` must
           contain required data, in this case at least `reply_id`.
           """
-          callback :cb_send_reply, _event, %{"reply_id" => reply_id} do
+          callback :cb_send_reply, _event, %{reply_id: reply_id} do
             {{:send_reply, reply_id, []}, []}
           end
 
@@ -147,8 +147,8 @@ defmodule Helix.Story.Model.Step.Macros do
           Predefined callback that is used by `on_process_started` listener.
           """
           callback :cb_process_started, event, meta do
-            if to_string(event.process.type) == meta["type"] do
-              relay_callback meta["relay_cb"], event, meta
+            if to_string(event.process.type) == meta.type do
+              relay_callback meta.relay_cb, event, meta
             else
               {:noop, []}
             end
@@ -171,8 +171,8 @@ defmodule Helix.Story.Model.Step.Macros do
     quote do
 
       def unquote(name)(var!(event) = unquote(event), meta = unquote(meta)) do
-        step_entity_id = meta["step_entity_id"] |> Entity.ID.cast!()
-        step_contact_id = meta["step_contact_id"] |> String.to_existing_atom()
+        step_entity_id = meta.step_entity_id |> Entity.ID.cast!()
+        step_contact_id = meta.step_contact_id |> String.to_existing_atom()
 
         var!(event)  # Mark as used
 

--- a/lib/story/model/step/macros.ex
+++ b/lib/story/model/step/macros.ex
@@ -355,6 +355,16 @@ defmodule Helix.Story.Model.Step.Macros do
       def handle_event(step = unquote(step), unquote(event), unquote(meta)) do
         unquote(
           case opts do
+            [do: :complete, send_opts: send_opts] ->
+              quote do
+                {{:complete, unquote(send_opts)}, step, []}
+              end
+
+            [do: :complete] ->
+              quote do
+                {:complete, step, []}
+              end
+
             [do: block] ->
               block
 
@@ -383,16 +393,6 @@ defmodule Helix.Story.Model.Step.Macros do
                   step,
                   []
                 }
-              end
-
-            [do: :complete, send_opts: send_opts] ->
-              quote do
-                {{:complete, unquote(send_opts)}, step, []}
-              end
-
-            :complete ->
-              quote do
-                {:complete, step, []}
               end
 
             [restart: true, reason: reason, checkpoint: checkpoint] ->

--- a/lib/story/model/step/steppable.ex
+++ b/lib/story/model/step/steppable.ex
@@ -158,7 +158,7 @@ defprotocol Helix.Story.Model.Steppable do
   alias Helix.Story.Model.Step
 
   @spec start(Step.t) ::
-    {:ok | :error, Step.t, [Event.t]}
+    {:ok | :error, Step.t, [Event.t], Step.send_opts}
   @doc """
   Function called when the previous step was completed. It has the purpose of
   setting up the new step, preparing its environment and generating any objects
@@ -267,12 +267,21 @@ defprotocol Helix.Story.Model.Steppable do
   """
   def format_meta(step)
 
-  @spec get_replies(Step.t, Step.email_id) ::
+  @spec get_emails(Step.t) ::
+    Step.emails
+  @doc """
+  Returns all registered emails for that step.
+
+  Must not be implemented nor called directly. Use `Step.get_emails/1`.
+  """
+  def get_emails(step)
+
+  @spec get_replies_of(Step.t, Step.email_id) ::
     [Step.reply_id]
   @doc """
   Returns all possible unlocked replies of an email.
 
-  Must not be implemented nor called directly. Instead, use `Step.get_replies/1`
+  Must not be implemented nor called directly. Use `Step.get_replies_of/2`.
   """
-  def get_replies(step, email_id)
+  def get_replies_of(step, email_id)
 end

--- a/test/core/listener/event/handler/listener_test.exs
+++ b/test/core/listener/event/handler/listener_test.exs
@@ -76,7 +76,7 @@ defmodule Helix.Core.Listener.Event.Handler.ListenerTest do
       assert_receive :hello_joe
       assert_receive {:hello_meta, meta}
 
-      assert meta["entity_id"] == to_string(file_downloaded.entity_id)
+      assert meta.entity_id == to_string(file_downloaded.entity_id)
     end
   end
 end

--- a/test/features/storyline/quests/tutorial_test.exs
+++ b/test/features/storyline/quests/tutorial_test.exs
@@ -20,6 +20,8 @@ defmodule Helix.Test.Features.Storyline.Quests.Tutorial do
   @moduletag :feature
 
   describe "tutorial" do
+
+    skip_on_travis_slowpoke()
     test "flow" do
       {server_socket, %{account: account, manager: manager}} =
         ChannelSetup.join_storyline_server()

--- a/test/story/event/handler/story_test.exs
+++ b/test/story/event/handler/story_test.exs
@@ -64,13 +64,15 @@ defmodule Helix.Story.Event.Handler.StoryTest do
       assert story_step.meta.cracker_id
 
       # Advance a few messages so we can check that it rolled back to checkpoint
-      StoryHelper.reply(story_step)
+      %{entry: story_step} = StoryHelper.send_fake_email(step, "wat")
 
-      # There are 3 registered emails (2 from contact and 1 reply)
+      # And for the sake of testability, let's pretend that we are allowed to
+      # reply back with `foobar`
+      story_step = %{story_step| allowed_replies: ["foobar"]}
+
+      # There are 2 registered messages (first one from step setup + "wat")
       story_email = StoryQuery.fetch_email(step.entity_id, step.contact)
-      assert length(story_email.emails) == 3
-
-      %{entry: story_step} = StoryQuery.fetch_step(step.entity_id, step.contact)
+      assert length(story_email.emails) == 2
 
       # Remove the file
       story_step.meta.cracker_id

--- a/test/story/model/macro_test.exs
+++ b/test/story/model/macro_test.exs
@@ -5,7 +5,6 @@ defmodule Helix.Story.Model.MacroTest do
   import ExUnit.CaptureLog
 
   alias Helix.Software.Internal.File, as: FileInternal
-  alias Helix.Story.Event.Email.Sent, as: StoryEmailSentEvent
   alias Helix.Story.Model.Steppable
 
   alias Helix.Test.Event.Setup, as: EventSetup
@@ -26,11 +25,12 @@ defmodule Helix.Story.Model.MacroTest do
       # reply_to_e2 tests the `send` block
       r2_event = EventSetup.Story.reply_sent(step, "reply_to_e2", "e2")
 
-      {action, _, [event]} = Steppable.handle_event(step, r2_event, %{})
+      {{action, email_id, meta, _}, _, []} =
+        Steppable.handle_event(step, r2_event, %{})
 
-      assert action == :noop
-      assert %StoryEmailSentEvent{} = event
-      assert event.email.id == "e3"
+      assert action == :send_email
+      assert email_id == "e3"
+      assert meta == %{}
 
       # reply_to_e3 tests the `complete` block
       r3_event = EventSetup.Story.reply_sent(step, "reply_to_e3", "e3")

--- a/test/support/event/helper.ex
+++ b/test/support/event/helper.ex
@@ -1,10 +1,23 @@
 defmodule Helix.Test.Event.Helper do
 
   alias Helix.Event
+  alias Helix.Event.State.Timer, as: EventStateTimer
 
+  @doc """
+  Emits an event (no relay)
+  """
   def emit(event),
     do: Event.emit(event)
 
+  @doc """
+  Returns the underlying process (if any) of the event
+  """
   def get_process(event),
     do: Event.get_process(event)
+
+  @doc """
+  Immediately emit all events that are awaiting for their timer to complete
+  """
+  def flush_timer,
+    do: EventStateTimer.flush()
 end

--- a/test/support/story/fake_steps.ex
+++ b/test/support/story/fake_steps.ex
@@ -47,7 +47,7 @@ defmodule Helix.Story.Mission.FakeSteps do
     empty_setup()
 
     def start(step),
-      do: {:ok, step, []}
+      do: {:ok, step, [], []}
 
     def complete(step),
       do: {:ok, step, []}
@@ -74,7 +74,7 @@ defmodule Helix.Story.Mission.FakeSteps do
     empty_setup()
 
     def start(step),
-      do: {:ok, step, []}
+      do: {:ok, step, [], []}
 
     def complete(step),
       do: {:ok, step, []}
@@ -87,7 +87,7 @@ defmodule Helix.Story.Mission.FakeSteps do
     empty_setup()
 
     def start(step),
-      do: {:ok, step, []}
+      do: {:ok, step, [], []}
 
     def complete(step),
       do: {:ok, step, []}
@@ -103,7 +103,7 @@ defmodule Helix.Story.Mission.FakeSteps do
     empty_setup()
 
     def start(step),
-      do: {:ok, step, []}
+      do: {:ok, step, [], []}
 
     def complete(step),
       do: {:ok, step, []}
@@ -119,7 +119,7 @@ defmodule Helix.Story.Mission.FakeSteps do
     empty_setup()
 
     def start(step),
-      do: {:ok, step, []}
+      do: {:ok, step, [], []}
 
     def complete(step),
       do: {:ok, step, []}
@@ -135,14 +135,14 @@ defmodule Helix.Story.Mission.FakeSteps do
     require Logger
 
     email "e1",
-      reply: ["reply_to_e1"],
+      replies: ["reply_to_e1"],
       locked: ["locked_reply_to_e1"]
 
     email "e2",
-      reply: ["reply_to_e2"]
+      replies: ["reply_to_e2"]
 
     email "e3",
-      reply: ["reply_to_e3"]
+      replies: ["reply_to_e3"]
 
     on_reply "reply_to_e1" do
       Logger.warn "replied_to_e1"
@@ -158,7 +158,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     def start(step) do
       send_email step, "e1"
-      {:ok, step, []}
+      {:ok, step, [], []}
     end
 
     def complete(step),
@@ -170,19 +170,19 @@ defmodule Helix.Story.Mission.FakeSteps do
   step TestMsgFlow do
 
     email "e1",
-      reply: ["reply_to_e1"]
+      replies: ["reply_to_e1"]
 
     on_reply "reply_to_e1",
       send: "e2"
 
     email "e2",
-      reply: ["reply_to_e2"]
+      replies: ["reply_to_e2"]
 
     on_reply "reply_to_e2",
       send: "e3"
 
     email "e3",
-      reply: ["reply_to_e3"]
+      replies: ["reply_to_e3"]
 
     on_reply "reply_to_e3",
       :complete
@@ -191,7 +191,7 @@ defmodule Helix.Story.Mission.FakeSteps do
 
     def start(step) do
       send_email step, "e1"
-      {:ok, step, []}
+      {:ok, step, [], []}
     end
 
     def complete(step),
@@ -212,7 +212,7 @@ defmodule Helix.Story.Mission.FakeContactOne do
     empty_setup()
 
     def start(step),
-      do: {:ok, step, []}
+      do: {:ok, step, [], []}
 
     def complete(step),
       do: {:ok, step, []}
@@ -232,7 +232,7 @@ defmodule Helix.Story.Mission.FakeContactTwo do
     empty_setup()
 
     def start(step),
-      do: {:ok, step, []}
+      do: {:ok, step, [], []}
 
     def complete(step),
       do: {:ok, step, []}

--- a/test/support/story/fake_steps.ex
+++ b/test/support/story/fake_steps.ex
@@ -152,7 +152,7 @@ defmodule Helix.Story.Mission.FakeSteps do
       send: "e3"
 
     on_reply "reply_to_e3",
-      :complete
+      do: :complete
 
     empty_setup()
 
@@ -185,7 +185,7 @@ defmodule Helix.Story.Mission.FakeSteps do
       replies: ["reply_to_e3"]
 
     on_reply "reply_to_e3",
-      :complete
+      do: :complete
 
     empty_setup()
 

--- a/test/support/story/macros.ex
+++ b/test/support/story/macros.ex
@@ -3,16 +3,17 @@ defmodule Helix.Test.Story.Macros do
   alias HELL.Utils
 
   @doc """
-  Asserts that the story has transitioned from `expected_from` to `expected_to`
+  Asserts that the story has transitioned from the current one (identified by
+  `name` on StepVars) to the next one (identified by `next` on StepVars).
   """
-  defmacro assert_transition(event, expected_from, expected_to) do
+  defmacro assert_transition(event, step_var) do
     quote do
 
       event_from = unquote(event).data.previous_step
       event_to = unquote(event).data.next_step
 
-      assert String.contains?(event_from, unquote(expected_from))
-      assert String.contains?(event_to, unquote(expected_to))
+      assert String.contains?(event_from, unquote(step_var).name)
+      assert String.contains?(event_to, unquote(step_var).next)
 
     end
   end
@@ -21,22 +22,54 @@ defmodule Helix.Test.Story.Macros do
   Asserts that the received email is the one expected, including the allowed
   replies and the contact/step are the same as before.
   """
-  defmacro assert_email(event, expected_email, replies, step) do
+  defmacro assert_email(event, expected_email, replies, step_var) do
     quote do
 
       event_data = unquote(event).data
       replies = Utils.ensure_list(unquote(replies))
 
+      expected_email = Map.fetch!(unquote(step_var), unquote(expected_email))
+
       assert unquote(event).event == "story_email_sent"
-      assert event_data.email_id == unquote(expected_email)
+      assert event_data.email_id == expected_email
 
       Enum.each(replies, fn reply ->
+        reply = Map.fetch!(unquote(step_var), reply)
         assert Enum.member?(event_data.replies, reply)
       end)
 
-      assert to_string(unquote(step).contact) == event_data.contact_id
-      assert to_string(unquote(step).name) == event_data.step
+      assert event_data.contact_id == to_string(unquote(step_var).contact)
+      assert event_data.step =~ to_string(unquote(step_var).name)
 
+    end
+  end
+
+  @doc """
+  Asserts that the received reply is the one expected, including the allowed
+  replies, which message it was replying to, and the contact/step are the same.
+
+  NOTE: Not to confuse with `assert_reply/4` macro on `Phoenix.ChannelTest`.
+  """
+  defmacro assert_reply(event, expected_reply, reply_to, replies, step_var) do
+    quote do
+
+      event_data = unquote(event).data
+      replies = Utils.ensure_list(unquote(replies))
+
+      expected_reply = Map.fetch!(unquote(step_var), unquote(expected_reply))
+      reply_to = Map.fetch!(unquote(step_var), unquote(reply_to))
+
+      assert unquote(event).event == "story_reply_sent"
+      assert event_data.reply_id == expected_reply
+      assert event_data.reply_to == reply_to
+
+      Enum.each(replies, fn reply ->
+        reply = Map.fetch!(unquote(step_var), reply)
+        assert Enum.member?(event_data.replies, reply)
+      end)
+
+      assert event_data.contact_id == to_string(unquote(step_var).contact)
+      assert event_data.step =~ to_string(unquote(step_var).name)
     end
   end
 end

--- a/test/support/story/vars.ex
+++ b/test/support/story/vars.ex
@@ -8,14 +8,25 @@ defmodule Helix.Test.Story.Vars do
     contact: %{
       friend: "friend"
     },
-    step: %{
-      setup_pc: %{
+    tutorial: %{
+      setup: %{
+        contact: "friend",
         name: "setup_pc",
         next: "download_cracker",
         msg1: "welcome",
         msg2: "back_thanks",
         msg3: "watchiadoing",
         msg4: "hell_yeah",
+      },
+      dl_crc: %{
+        contact: "friend",
+        name: "download_cracker",
+        next: "nasty_virus",
+        msg1: "download_cracker1",
+        msg2: "about_that",
+        msg3: "yeah_right",
+        msg4: "downloaded",
+        msg5: "nothing_now"
       }
     }
   }


### PR DESCRIPTION
Most of this PR work was directed to making the Storyline message flow more flexible

- [x] Add `Step.callback_actions`:
  - `{:send_email, email_id, email_meta, send_opts}`
  - `{:send_reply, reply_id, send_opts}`

- [x] Redesigned Steps to have `emails` and `replies`, both of which are `messages` (`emails` may only be sent by the NPC, while `replies` may only sent by the player).
  - Implementation
  - Fix specs

- [x] New `reply` and `on_email` macros

- [x] Clean up PoC implementation
- [x] Doc everything
- [x] Prepare the transition to the next step after `DownloadCracker`



#### Incidental

- `Event.emit_after` with support for `Event.relay`
- Breakdown of `Listenable` macros into `listenable/1` and `listen/2`.
- Added `flush` helper on `Event.State.Timer` for testing and system restarts
- Enhanced callbacks and `story_listen` macro on `Step.Macros`
- Added `on_process_started` listener macro on `Step.Macros`
- `assert_reply/5` helper/macro for `Helix.Test.Story.Macros`
- Now the `Listener.meta` has its keys automatically atomized for ease of use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/385)
<!-- Reviewable:end -->
