### PR TITLE
Return Database.Virus information on DatabaseIndex

### DIFF
--- a/events.json
+++ b/events.json
@@ -17,10 +17,11 @@
     },
     "Entity.Database": {
         "receives": [
-            "Server.Password.Acquired",
             "Bank.Account.Password.Revealed",
             "Bank.Token.Acquired",
-            "Bank.Account.Login"
+            "Bank.Account.Login",
+            "Server.Password.Acquired",
+            "Virus.Installed"
         ],
         "emits": []
     },

--- a/lib/entity/action/database.ex
+++ b/lib/entity/action/database.ex
@@ -11,6 +11,7 @@ defmodule Helix.Entity.Action.Database do
   alias Helix.Network.Query.Network, as: NetworkQuery
   alias Helix.Server.Model.Server
   alias Helix.Server.Query.Server, as: ServerQuery
+  alias Helix.Software.Model.File
   alias Helix.Universe.Bank.Model.BankAccount
   alias Helix.Universe.Bank.Model.BankToken
   alias Helix.Entity.Internal.Database, as: DatabaseInternal
@@ -28,9 +29,8 @@ defmodule Helix.Entity.Action.Database do
   with extra information like password or notes. Modifying these extra data
   should be done by with `update_*` functions.
   """
-  def add_server(entity, network, ip, server) do
-    DatabaseInternal.add_server(entity, network, ip, server, :npc)
-  end
+  def add_server(entity, network, ip, server),
+    do: DatabaseInternal.add_server(entity, network, ip, server, :npc)
 
   @spec add_bank_account(Entity.idt, BankAccount.t) ::
     {:ok, Database.BankAccount.t}
@@ -46,6 +46,18 @@ defmodule Helix.Entity.Action.Database do
     atm_ip = ServerQuery.get_ip(bank_account.atm_id, NetworkQuery.internet())
     DatabaseInternal.add_bank_account(entity, bank_account, atm_ip)
   end
+
+  @spec add_virus(Entity.id, Server.id, File.id) ::
+    {:ok, Database.Virus.t}
+    | {:error, Database.Virus.changeset}
+  @doc """
+  Adds a new virus entry to the database.
+
+  All viruses on the database must be linked to a `Database.Server`. This FK
+  will be enforced.
+  """
+  def add_virus(entity_id, server_id, file_id),
+    do: DatabaseInternal.add_virus(entity_id, server_id, file_id)
 
   @spec update_server_password(
     Entity.idt,

--- a/lib/entity/action/database.ex
+++ b/lib/entity/action/database.ex
@@ -14,14 +14,13 @@ defmodule Helix.Entity.Action.Database do
   alias Helix.Universe.Bank.Model.BankAccount
   alias Helix.Universe.Bank.Model.BankToken
   alias Helix.Entity.Internal.Database, as: DatabaseInternal
-  alias Helix.Entity.Model.DatabaseBankAccount
-  alias Helix.Entity.Model.DatabaseServer
+  alias Helix.Entity.Model.Database
   alias Helix.Entity.Model.Entity
   alias Helix.Entity.Query.Database, as: DatabaseQuery
 
   @spec add_server(Entity.idt, Network.idt, IPv4.t, Server.idt) ::
-    {:ok, DatabaseServer.t}
-    | {:error, DatabaseServer.changeset}
+    {:ok, Database.Server.t}
+    | {:error, Database.Server.changeset}
   @doc """
   Adds a new server entry to the database.
 
@@ -34,8 +33,8 @@ defmodule Helix.Entity.Action.Database do
   end
 
   @spec add_bank_account(Entity.idt, BankAccount.t) ::
-    {:ok, DatabaseBankAccount.t}
-    | {:error, DatabaseBankAccount.changeset}
+    {:ok, Database.BankAccount.t}
+    | {:error, Database.BankAccount.changeset}
   @doc """
   Adds a new bank account entry to the database.
 
@@ -55,8 +54,8 @@ defmodule Helix.Entity.Action.Database do
     Server.id,
     Server.password)
   ::
-    {:ok, DatabaseServer.t}
-    | {:error, DatabaseServer.changeset}
+    {:ok, Database.Server.t}
+    | {:error, Database.Server.changeset}
     | {:error, {:server, :belongs_to_entity}}
   @doc """
   Updates the password of the server entry. It is usually called when:
@@ -76,8 +75,8 @@ defmodule Helix.Entity.Action.Database do
   end
 
   @spec update_bank_password(Entity.idt, BankAccount.t, String.t) ::
-    {:ok, DatabaseBankAccount.t}
-    | {:error, DatabaseBankAccount.changeset}
+    {:ok, Database.BankAccount.t}
+    | {:error, Database.BankAccount.changeset}
     | {:error, {:bank_account, :belongs_to_entity}}
   @doc """
   Updates the password of the bank account entry.
@@ -95,8 +94,8 @@ defmodule Helix.Entity.Action.Database do
   end
 
   @spec update_bank_token(Entity.idt, BankAccount.t, BankToken.id) ::
-    {:ok, DatabaseBankAccount.t}
-    | {:error, DatabaseBankAccount.changeset}
+    {:ok, Database.BankAccount.t}
+    | {:error, Database.BankAccount.changeset}
     | {:error, {:bank_account, :belongs_to_entity}}
   @doc """
   Updates the token of the bank account entry.
@@ -114,8 +113,8 @@ defmodule Helix.Entity.Action.Database do
   end
 
   @spec update_bank_login(Entity.idt, BankAccount.t, BankToken.id | nil) ::
-    {:ok, DatabaseBankAccount.t}
-    | {:error, DatabaseBankAccount.changeset}
+    {:ok, Database.BankAccount.t}
+    | {:error, Database.BankAccount.changeset}
     | {:error, {:bank_account, :belongs_to_entity}}
   @doc """
   Updates the bank account entry after a login. This step is the one that adds
@@ -186,7 +185,7 @@ defmodule Helix.Entity.Action.Database do
   end
 
   @spec fetch_or_create_bank_entry(Entity.t, BankAccount.t) ::
-    DatabaseBankAccount.t
+    Database.BankAccount.t
   defp fetch_or_create_bank_entry(entity, account) do
     case DatabaseQuery.fetch_bank_account(entity, account) do
       entry = %{} ->
@@ -198,7 +197,7 @@ defmodule Helix.Entity.Action.Database do
   end
 
   @spec fetch_or_create_server(Entity.t, Network.idt, IPv4.t, Server.id) ::
-    DatabaseServer.t
+    Database.Server.t
   defp fetch_or_create_server(entity, network_id, ip, server_id) do
     case DatabaseQuery.fetch_server(entity, network_id, ip) do
       entry = %{} ->

--- a/lib/entity/event/handler/database.ex
+++ b/lib/entity/event/handler/database.ex
@@ -1,5 +1,6 @@
 defmodule Helix.Entity.Event.Handler.Database do
 
+  alias Helix.Event
   alias Helix.Entity.Action.Database, as: DatabaseAction
   alias Helix.Entity.Query.Entity, as: EntityQuery
 
@@ -11,6 +12,8 @@ defmodule Helix.Entity.Event.Handler.Database do
     as: BankAccountLoginEvent
   alias Helix.Universe.Bank.Event.Bank.Account.Token.Acquired,
     as: BankAccountTokenAcquiredEvent
+  alias Helix.Software.Event.Virus.Installed,
+    as: VirusInstalledEvent
 
   @doc """
   Handler called when a BruteforceProcess has finished and the target server
@@ -71,5 +74,18 @@ defmodule Helix.Entity.Event.Handler.Database do
       event.account,
       event.token_id
     )
+  end
+
+  @doc """
+  Handler called after a virus is installed. Its main goal is to add the virus
+  to the Hacked Database (`Database.Virus`).
+  """
+  def on_virus_installed(event = %VirusInstalledEvent{}) do
+    server_id =
+      event
+      |> Event.get_process()
+      |> Map.fetch!(:target_id)
+
+    DatabaseAction.add_virus(event.entity_id, server_id, event.file.file_id)
   end
 end

--- a/lib/entity/internal/database.ex
+++ b/lib/entity/internal/database.ex
@@ -3,6 +3,7 @@ defmodule Helix.Entity.Internal.Database do
   alias HELL.IPv4
   alias Helix.Network.Model.Network
   alias Helix.Server.Model.Server
+  alias Helix.Software.Model.File
   alias Helix.Universe.Bank.Model.BankAccount
   alias Helix.Universe.Bank.Model.BankToken
   alias Helix.Entity.Model.Entity
@@ -40,6 +41,15 @@ defmodule Helix.Entity.Internal.Database do
     entity
     |> Database.BankAccount.Query.by_entity()
     |> Database.BankAccount.Query.by_account(acc.atm_id, acc.account_number)
+    |> Repo.one()
+  end
+
+  @spec fetch_virus(File.id) ::
+    Database.Virus.t
+    | nil
+  def fetch_virus(file_id) do
+    file_id
+    |> Database.Virus.Query.by_file()
     |> Repo.one()
   end
 
@@ -100,6 +110,21 @@ defmodule Helix.Entity.Internal.Database do
 
     params
     |> Database.BankAccount.create_changeset()
+    |> Repo.insert()
+  end
+
+  @spec add_virus(Entity.id, Server.id, File.id) ::
+    {:ok, Database.Virus.t}
+    | {:error, Database.Virus.changeset}
+  def add_virus(entity_id, server_id, file_id) do
+    params = %{
+      entity_id: entity_id,
+      server_id: server_id,
+      file_id: file_id
+    }
+
+    params
+    |> Database.Virus.create_changeset()
     |> Repo.insert()
   end
 

--- a/lib/entity/internal/database.ex
+++ b/lib/entity/internal/database.ex
@@ -1,6 +1,5 @@
 defmodule Helix.Entity.Internal.Database do
 
-  alias HELL.IPv4
   alias Helix.Network.Model.Network
   alias Helix.Server.Model.Server
   alias Helix.Software.Model.File
@@ -24,13 +23,14 @@ defmodule Helix.Entity.Internal.Database do
       bank_accounts: [Database.BankAccount.t]
     }
 
-  @spec fetch_server(Entity.idt, Network.idt, IPv4.t) ::
+  @spec fetch_server(Entity.idt, Network.idt, Network.ip) ::
     Database.Server.t
     | nil
   def fetch_server(entity, network, server_ip) do
     entity
     |> Database.Server.Query.by_entity()
     |> Database.Server.Query.by_nip(network, server_ip)
+    |> Database.Server.Query.join_database_viruses()
     |> Repo.one()
   end
 
@@ -68,6 +68,7 @@ defmodule Helix.Entity.Internal.Database do
     entity
     |> Database.Server.Query.by_entity()
     |> Database.Server.Query.order_by_last_update()
+    |> Database.Server.Query.join_database_viruses()
     |> Repo.all()
   end
 
@@ -81,7 +82,11 @@ defmodule Helix.Entity.Internal.Database do
   end
 
   @spec add_server(
-    Entity.idt, Network.idt, IPv4.t, Server.idt, Database.Server.server_type)
+    Entity.idt,
+    Network.idt,
+    Network.ip,
+    Server.idt,
+    Database.Server.server_type)
   ::
     entry_server_repo_return
   def add_server(entity, network, ip, server, server_type) do
@@ -98,7 +103,7 @@ defmodule Helix.Entity.Internal.Database do
     |> Repo.insert()
   end
 
-  @spec add_bank_account(Entity.t, BankAccount.t, IPv4.t) ::
+  @spec add_bank_account(Entity.t, BankAccount.t, Network.ip) ::
     entry_bank_account_repo_return
   def add_bank_account(entity, bank_account, atm_ip) do
     params = %{

--- a/lib/entity/internal/database.ex
+++ b/lib/entity/internal/database.ex
@@ -6,41 +6,40 @@ defmodule Helix.Entity.Internal.Database do
   alias Helix.Universe.Bank.Model.BankAccount
   alias Helix.Universe.Bank.Model.BankToken
   alias Helix.Entity.Model.Entity
-  alias Helix.Entity.Model.DatabaseBankAccount
-  alias Helix.Entity.Model.DatabaseServer
+  alias Helix.Entity.Model.Database
   alias Helix.Entity.Repo
 
   @type entry_server_repo_return ::
-    {:ok, DatabaseServer.t}
-    | {:error, DatabaseServer.changeset}
+    {:ok, Database.Server.t}
+    | {:error, Database.Server.changeset}
 
   @type entry_bank_account_repo_return ::
-    {:ok, DatabaseBankAccount.t}
-    | {:error, DatabaseBankAccount.changeset}
+    {:ok, Database.BankAccount.t}
+    | {:error, Database.BankAccount.changeset}
 
   @type full_database ::
     %{
-      servers: [DatabaseServer.t],
-      bank_accounts: [DatabaseBankAccount.t]
+      servers: [Database.Server.t],
+      bank_accounts: [Database.BankAccount.t]
     }
 
   @spec fetch_server(Entity.idt, Network.idt, IPv4.t) ::
-    DatabaseServer.t
+    Database.Server.t
     | nil
   def fetch_server(entity, network, server_ip) do
     entity
-    |> DatabaseServer.Query.by_entity()
-    |> DatabaseServer.Query.by_nip(network, server_ip)
+    |> Database.Server.Query.by_entity()
+    |> Database.Server.Query.by_nip(network, server_ip)
     |> Repo.one()
   end
 
   @spec fetch_bank_account(Entity.t, BankAccount.t) ::
-    DatabaseBankAccount.t
+    Database.BankAccount.t
     | nil
   def fetch_bank_account(entity, acc) do
     entity
-    |> DatabaseBankAccount.Query.by_entity()
-    |> DatabaseBankAccount.Query.by_bank_account(acc.atm_id, acc.account_number)
+    |> Database.BankAccount.Query.by_entity()
+    |> Database.BankAccount.Query.by_account(acc.atm_id, acc.account_number)
     |> Repo.one()
   end
 
@@ -54,25 +53,25 @@ defmodule Helix.Entity.Internal.Database do
   end
 
   @spec get_server_entries(Entity.t) ::
-    [DatabaseServer.t]
+    [Database.Server.t]
   defp get_server_entries(entity) do
     entity
-    |> DatabaseServer.Query.by_entity()
-    |> DatabaseServer.Query.order_by_last_update()
+    |> Database.Server.Query.by_entity()
+    |> Database.Server.Query.order_by_last_update()
     |> Repo.all()
   end
 
   @spec get_bank_account_entries(Entity.t) ::
-    [DatabaseBankAccount.t]
+    [Database.BankAccount.t]
   defp get_bank_account_entries(entity) do
     entity
-    |> DatabaseBankAccount.Query.by_entity()
-    |> DatabaseBankAccount.Query.order_by_last_update()
+    |> Database.BankAccount.Query.by_entity()
+    |> Database.BankAccount.Query.order_by_last_update()
     |> Repo.all()
   end
 
   @spec add_server(
-    Entity.idt, Network.idt, IPv4.t, Server.idt, DatabaseServer.server_type)
+    Entity.idt, Network.idt, IPv4.t, Server.idt, Database.Server.server_type)
   ::
     entry_server_repo_return
   def add_server(entity, network, ip, server, server_type) do
@@ -85,7 +84,7 @@ defmodule Helix.Entity.Internal.Database do
     }
 
     params
-    |> DatabaseServer.create_changeset()
+    |> Database.Server.create_changeset()
     |> Repo.insert()
   end
 
@@ -100,35 +99,35 @@ defmodule Helix.Entity.Internal.Database do
     }
 
     params
-    |> DatabaseBankAccount.create_changeset()
+    |> Database.BankAccount.create_changeset()
     |> Repo.insert()
   end
 
-  @spec update_server_password(DatabaseServer.t, Server.password) ::
+  @spec update_server_password(Database.Server.t, Server.password) ::
     entry_server_repo_return
   def update_server_password(entry, password),
     do: update_server(entry, %{password: password})
 
-  @spec update_server(DatabaseServer.t, DatabaseServer.update_params) ::
+  @spec update_server(Database.Server.t, Database.Server.update_params) ::
     entry_server_repo_return
   defp update_server(entry, params) do
     entry
-    |> DatabaseServer.update_changeset(params)
+    |> Database.Server.update_changeset(params)
     |> Repo.update()
   end
 
-  @spec update_bank_password(DatabaseBankAccount.t, String.t) ::
+  @spec update_bank_password(Database.BankAccount.t, String.t) ::
     entry_bank_account_repo_return
   def update_bank_password(entry, password),
     do: update_bank_account(entry, %{password: password})
 
-  @spec update_bank_token(DatabaseBankAccount.t, BankToken.id) ::
+  @spec update_bank_token(Database.BankAccount.t, BankToken.id) ::
     entry_bank_account_repo_return
   def update_bank_token(entry, token),
     do: update_bank_account(entry, %{token: token})
 
   @spec update_bank_login(
-    DatabaseBankAccount.t, BankAccount.t, BankToken.id | nil)
+    Database.BankAccount.t, BankAccount.t, BankToken.id | nil)
   ::
     entry_bank_account_repo_return
   def update_bank_login(entry, account, token_id) do
@@ -150,26 +149,26 @@ defmodule Helix.Entity.Internal.Database do
   end
 
   @spec update_bank_account(
-    DatabaseBankAccount.t, DatabaseBankAccount.update_params)
+    Database.BankAccount.t, Database.BankAccount.update_params)
   ::
     entry_bank_account_repo_return
   defp update_bank_account(entry, params) do
     entry
-    |> DatabaseBankAccount.update_changeset(params)
+    |> Database.BankAccount.update_changeset(params)
     |> Repo.update()
   end
 
-  @spec delete_server(DatabaseServer.t) ::
+  @spec delete_server(Database.Server.t) ::
     :ok
-  def delete_server(entry = %DatabaseServer{}) do
+  def delete_server(entry = %Database.Server{}) do
     Repo.delete(entry)
 
     :ok
   end
 
-  @spec delete_bank_account(DatabaseBankAccount.t) ::
+  @spec delete_bank_account(Database.BankAccount.t) ::
     :ok
-  def delete_bank_account(entry = %DatabaseBankAccount{}) do
+  def delete_bank_account(entry = %Database.BankAccount{}) do
     Repo.delete(entry)
 
     :ok

--- a/lib/entity/model/database/bank_account.ex
+++ b/lib/entity/model/database/bank_account.ex
@@ -1,4 +1,4 @@
-defmodule Helix.Entity.Model.DatabaseBankAccount do
+defmodule Helix.Entity.Model.Database.BankAccount do
 
   use Ecto.Schema
 
@@ -42,10 +42,9 @@ defmodule Helix.Entity.Model.DatabaseBankAccount do
     optional(:token) => String.t
   }
 
-  @creation_fields ~w/entity_id atm_id atm_ip account_number/a
-  @update_fields ~w/notes password token known_balance last_login_date/a
-
-  @required_creation ~w/entity_id atm_id atm_ip account_number/a
+  @creation_fields [:entity_id, :atm_id, :atm_ip, :account_number]
+  @update_fields [:notes, :password, :token, :known_balance, :last_login_date]
+  @required_creation [:entity_id, :atm_id, :atm_ip, :account_number]
 
   @notes_max_length 1024
 
@@ -102,17 +101,17 @@ defmodule Helix.Entity.Model.DatabaseBankAccount do
     alias HELL.IPv4
     alias Helix.Universe.Bank.Model.ATM
     alias Helix.Universe.Bank.Model.BankAccount
-    alias Helix.Entity.Model.DatabaseBankAccount
+    alias Helix.Entity.Model.Database
     alias Helix.Entity.Model.Entity
 
     @spec by_entity(Queryable.t, Entity.idtb) ::
       Queryable.t
-    def by_entity(query \\ DatabaseBankAccount, id),
+    def by_entity(query \\ Database.BankAccount, id),
       do: where(query, [d], d.entity_id == ^id)
 
-    @spec by_bank_account(Queryable.t, ATM.idtb, BankAccount.account) ::
+    @spec by_account(Queryable.t, ATM.idtb, BankAccount.account) ::
       Queryable.t
-    def by_bank_account(query \\ DatabaseBankAccount, atm, account),
+    def by_account(query \\ Database.BankAccount, atm, account),
       do: where(query, [d], d.atm_id == ^atm and d.account_number == ^account)
 
     @spec order_by_last_update(Queryable.t) ::

--- a/lib/entity/model/database/server.ex
+++ b/lib/entity/model/database/server.ex
@@ -139,6 +139,8 @@ defmodule Helix.Entity.Model.Database.Server do
     def by_server(query \\ Database.Server, id),
       do: where(query, [d], d.server_id == ^id)
 
+    @spec join_database_viruses(Queryable.t) ::
+      Queryable.t
     def join_database_viruses(query) do
       query
       |> join(:left, [ds], dv in assoc(ds, :viruses))

--- a/lib/entity/model/database/server.ex
+++ b/lib/entity/model/database/server.ex
@@ -1,4 +1,4 @@
-defmodule Helix.Entity.Model.DatabaseServer do
+defmodule Helix.Entity.Model.Database.Server do
 
   use Ecto.Schema
 
@@ -43,13 +43,25 @@ defmodule Helix.Entity.Model.DatabaseServer do
   @type server_type ::
     Constant.t  # :npc | :vpc
 
-  @creation_fields ~w/entity_id network_id server_ip server_id server_type/a
-  @update_fields ~w/password alias notes last_update/a
+  @creation_fields [
+    :entity_id,
+    :network_id,
+    :server_ip,
+    :server_id,
+    :server_type
+  ]
+  @update_fields [:password, :alias, :notes, :last_update]
 
-  @required_creation ~w/entity_id network_id server_ip server_id server_type/a
+  @required_fields [
+    :entity_id,
+    :network_id,
+    :server_ip,
+    :server_id,
+    :server_type
+  ]
 
   # Maybe we could provide types for specific NPCs. eg: bank
-  @possible_server_types ~w/npc vpc/a
+  @possible_server_types [:npc, :vpc]
 
   @alias_max_length 64
   @notes_max_length 1024
@@ -79,7 +91,7 @@ defmodule Helix.Entity.Model.DatabaseServer do
   def create_changeset(params) do
     %__MODULE__{}
     |> cast(params, @creation_fields)
-    |> validate_required(@required_creation)
+    |> validate_required(@required_fields)
     |> validate_inclusion(:server_type, @possible_server_types)
     |> update_last_update()
   end
@@ -104,22 +116,22 @@ defmodule Helix.Entity.Model.DatabaseServer do
     alias HELL.IPv4
     alias Helix.Network.Model.Network
     alias Helix.Server.Model.Server
-    alias Helix.Entity.Model.DatabaseServer
+    alias Helix.Entity.Model.Database
     alias Helix.Entity.Model.Entity
 
     @spec by_entity(Queryable.t, Entity.idtb) ::
       Queryable.t
-    def by_entity(query \\ DatabaseServer, id),
+    def by_entity(query \\ Database.Server, id),
       do: where(query, [d], d.entity_id == ^id)
 
     @spec by_nip(Queryable.t, Network.idtb, IPv4.t) ::
       Queryable.t
-    def by_nip(query \\ DatabaseServer, network, ip),
+    def by_nip(query \\ Database.Server, network, ip),
       do: where(query, [d], d.network_id == ^network and d.server_ip == ^ip)
 
     @spec by_server(Queryable.t, Server.idtb) ::
       Queryable.t
-    def by_server(query \\ DatabaseServer, id),
+    def by_server(query \\ Database.Server, id),
       do: where(query, [d], d.server_id == ^id)
 
     @spec order_by_last_update(Queryable.t) ::

--- a/lib/entity/model/database/virus.ex
+++ b/lib/entity/model/database/virus.ex
@@ -1,0 +1,66 @@
+defmodule Helix.Entity.Model.Database.Virus do
+  @moduledoc """
+  `Database.Virus` keeps track of all viruses installed by the Entity, linking
+  it to a `Database.Server`. It is basically a cache over `Software.Virus`,
+  which holds all information about the virus, including its running time,
+  whether it's active or not etc.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import HELL.Ecto.Macros
+
+  alias Ecto.Changeset
+  alias Helix.Server.Model.Server
+  alias Helix.Software.Model.File
+  alias Helix.Entity.Model.Entity
+
+  @type changeset :: %Changeset{data: %__MODULE__{}}
+
+  @type t ::
+    %__MODULE__{
+      entity_id: Entity.id,
+      server_id: Server.id,
+      file_id: File.id
+    }
+
+  @type creation_params ::
+    %{
+      entity_id: Entity.id,
+      server_id: Server.id,
+      file_id: File.id
+    }
+
+  @creation_fields [:entity_id, :server_id, :file_id]
+  @required_fields [:entity_id, :server_id, :file_id]
+
+  @primary_key false
+  schema "database_viruses" do
+    field :entity_id, Entity.ID,
+      primary_key: true
+    field :server_id, Server.ID,
+      primary_key: true
+    field :file_id, File.ID,
+      primary_key: true
+  end
+
+  @spec create_changeset(creation_params) ::
+    changeset
+  def create_changeset(params) do
+    %__MODULE__{}
+    |> cast(params, @creation_fields)
+    |> validate_required(@required_fields)
+  end
+
+  query do
+
+    alias Helix.Entity.Model.Database
+    alias Helix.Entity.Model.Entity
+
+    @spec by_file(Queryable.t, File.id) ::
+      Queryable.t
+    def by_file(query \\ Database.Virus, file_id),
+      do: where(query, [dv], dv.file_id == ^file_id)
+  end
+end

--- a/lib/entity/public/index/database.ex
+++ b/lib/entity/public/index/database.ex
@@ -2,6 +2,7 @@ defmodule Helix.Entity.Public.Index.Database do
 
   alias HELL.ClientUtils
   alias HELL.HETypes
+  alias Helix.Software.Model.Virus
   alias Helix.Software.Public.Index, as: SoftwareIndex
   alias Helix.Software.Query.File, as: FileQuery
   alias Helix.Software.Query.Virus, as: VirusQuery
@@ -53,6 +54,7 @@ defmodule Helix.Entity.Public.Index.Database do
       name: String.t,
       version: float,
       type: String.t,
+      extension: String.t,
       running_time: seconds :: integer | nil,
       is_active: boolean
     }
@@ -105,7 +107,7 @@ defmodule Helix.Entity.Public.Index.Database do
     }
   end
 
-  @spec render_server(Database.Server.t, [term]) ::
+  @spec render_server(Database.Server.t, [Virus.t]) ::
     rendered_server
   defp render_server(entry = %Database.Server{}, entity_viruses) do
     rendered_viruses =
@@ -125,6 +127,8 @@ defmodule Helix.Entity.Public.Index.Database do
     }
   end
 
+  @spec render_virus(Database.Virus.t, [Virus.t]) ::
+    rendered_virus
   defp render_virus(entry = %Database.Virus{}, entity_viruses) do
     virus = Enum.find(entity_viruses, &(&1.file_id == entry.file_id))
 

--- a/lib/entity/public/index/database.ex
+++ b/lib/entity/public/index/database.ex
@@ -2,15 +2,14 @@ defmodule Helix.Entity.Public.Index.Database do
 
   alias HELL.ClientUtils
   alias HELL.HETypes
-  alias Helix.Entity.Model.DatabaseBankAccount
-  alias Helix.Entity.Model.DatabaseServer
+  alias Helix.Entity.Model.Database
   alias Helix.Entity.Model.Entity
   alias Helix.Entity.Query.Database, as: DatabaseQuery
 
   @type index ::
     %{
-      bank_accounts: [DatabaseBankAccount.t],
-      servers: [DatabaseServer.t]
+      bank_accounts: [Database.BankAccount.t],
+      servers: [Database.Server.t]
     }
 
   @type rendered_index ::
@@ -57,9 +56,9 @@ defmodule Helix.Entity.Public.Index.Database do
     }
   end
 
-  @spec render_bank_account(DatabaseBankAccount.t) ::
+  @spec render_bank_account(Database.BankAccount.t) ::
     rendered_bank_account
-  defp render_bank_account(entry = %DatabaseBankAccount{}) do
+  defp render_bank_account(entry = %Database.BankAccount{}) do
     last_login_date =
       if is_map(entry.last_login_date) do
         ClientUtils.to_timestamp(entry.last_login_date)
@@ -80,9 +79,9 @@ defmodule Helix.Entity.Public.Index.Database do
     }
   end
 
-  @spec render_server(DatabaseServer.t) ::
+  @spec render_server(Database.Server.t) ::
     rendered_server
-  defp render_server(entry = %DatabaseServer{}) do
+  defp render_server(entry = %Database.Server{}) do
     %{
       network_id: to_string(entry.network_id),
       ip: to_string(entry.server_ip),

--- a/lib/entity/query/database.ex
+++ b/lib/entity/query/database.ex
@@ -9,6 +9,7 @@ defmodule Helix.Entity.Query.Database do
 
   alias HELL.IPv4
   alias Helix.Network.Model.Network
+  alias Helix.Software.Model.File
   alias Helix.Universe.Bank.Model.BankAccount
   alias Helix.Entity.Internal.Database, as: DatabaseInternal
   alias Helix.Entity.Model.Entity
@@ -30,6 +31,15 @@ defmodule Helix.Entity.Query.Database do
   Returns the entry corresponding to the given bank account. May be outdated.
   """
   defdelegate fetch_bank_account(entity, account),
+    to: DatabaseInternal
+
+  @spec fetch_virus(File.id) ::
+    Database.Virus.t
+    | nil
+  @doc """
+  Returns the entry corresponding to the given virus.
+  """
+  defdelegate fetch_virus(file_id),
     to: DatabaseInternal
 
   @spec get_database(Entity.t) ::

--- a/lib/entity/query/database.ex
+++ b/lib/entity/query/database.ex
@@ -12,11 +12,10 @@ defmodule Helix.Entity.Query.Database do
   alias Helix.Universe.Bank.Model.BankAccount
   alias Helix.Entity.Internal.Database, as: DatabaseInternal
   alias Helix.Entity.Model.Entity
-  alias Helix.Entity.Model.DatabaseBankAccount
-  alias Helix.Entity.Model.DatabaseServer
+  alias Helix.Entity.Model.Database
 
   @spec fetch_server(Entity.idt, Network.idt, IPv4.t) ::
-    DatabaseServer.t
+    Database.Server.t
     | nil
   @doc """
   Returns the entry corresponding to the given server (nip).
@@ -25,7 +24,7 @@ defmodule Helix.Entity.Query.Database do
     to: DatabaseInternal
 
   @spec fetch_bank_account(Entity.idt, BankAccount.t) ::
-    DatabaseBankAccount.t
+    Database.BankAccount.t
     | nil
   @doc """
   Returns the entry corresponding to the given bank account. May be outdated.

--- a/lib/event/dispatcher.ex
+++ b/lib/event/dispatcher.ex
@@ -237,6 +237,10 @@ defmodule Helix.Event.Dispatcher do
     BankHandler.Bank.Account,
     :virus_collected
 
+  event SoftwareEvent.Virus.Installed,
+    EntityHandler.Database,
+    :on_virus_installed
+
   ##############################################################################
   # Story events
   ##############################################################################

--- a/lib/software/event/virus.ex
+++ b/lib/software/event/virus.ex
@@ -67,7 +67,7 @@ defmodule Helix.Software.Event.Virus do
   event Installed do
     @moduledoc """
     `VirusInstalledEvent` is fired when a virus has been installed by someone.
-    It one of the two possible results of FileInstallProcessedEvent (when the
+    It's one of the two possible results of FileInstallProcessedEvent (when the
     file is a virus), with the other being `VirusInstallFailedEvent`.
     """
 

--- a/lib/software/model/virus.ex
+++ b/lib/software/model/virus.ex
@@ -21,7 +21,7 @@ defmodule Helix.Software.Model.Virus do
       file_id: File.id,
       entity_id: Entity.id,
       is_active?: boolean,
-      running_time: seconds :: integer
+      running_time: seconds :: integer | nil
     }
 
   @typep wallet :: term

--- a/lib/software/public/index.ex
+++ b/lib/software/public/index.ex
@@ -38,6 +38,7 @@ defmodule Helix.Software.Public.Index do
       size: File.size,
       type: String.t,
       modules: modules,
+      version: float,
       name: String.t,
       extension: String.t,
       meta: map
@@ -107,12 +108,16 @@ defmodule Helix.Software.Public.Index do
         end)
       end
 
+    # TODO
+    version = 1.0
+
     %{
       id: to_string(file.file_id),
       path: file.path,
       size: file.file_size,
       type: to_string(file.software_type),
       modules: render_modules.(file.modules),
+      version: version,
       name: to_string(file.name),
       extension: extension,
       meta: file.meta

--- a/priv/repo/entity/migrations/20170401185838_initial_entity_domain.exs
+++ b/priv/repo/entity/migrations/20170401185838_initial_entity_domain.exs
@@ -20,6 +20,7 @@ defmodule Helix.Entity.Repo.Migrations.InitialEntityDomain do
         references(:entities, column: :entity_id, type: :inet),
         primary_key: true
     end
+    # create unique_index(:entity_servers, [:server_id]) at `AddDatabaseVirus`
 
     create table(:entity_components, primary_key: false) do
       add :entity_id,

--- a/priv/repo/entity/migrations/20180310194833_add_database_virus.exs
+++ b/priv/repo/entity/migrations/20180310194833_add_database_virus.exs
@@ -1,0 +1,20 @@
+defmodule Helix.Entity.Repo.Migrations.AddDatabaseVirus do
+  use Ecto.Migration
+
+  def change do
+    # UNIQUE index on `server_id` required for FK purposes
+    create unique_index(:entity_servers, [:server_id])
+
+    create table(:database_viruses, primary_key: false) do
+      add :entity_id,
+        references(:entities, column: :entity_id, type: :inet),
+        primary_key: true
+      add :server_id,
+        references(:entity_servers, column: :server_id, type: :inet),
+        primary_key: true
+      add :file_id, :inet, primary_key: true
+    end
+
+    create unique_index(:database_viruses, [:file_id])
+  end
+end

--- a/test/entity/internal/database_test.exs
+++ b/test/entity/internal/database_test.exs
@@ -19,11 +19,30 @@ defmodule Helix.Entity.Internal.DatabaseTest do
     test "returns the entry when input exists" do
       {entry, _} = DatabaseSetup.entry_server()
 
-      assert DatabaseInternal.fetch_server(
-        entry.entity_id,
-        entry.network_id,
-        entry.server_ip
-      )
+      assert entry ==
+        DatabaseInternal.fetch_server(
+          entry.entity_id, entry.network_id, entry.server_ip
+        )
+    end
+
+    test "returns the entry when input exists (with linked viruses)" do
+      {entry, _} = DatabaseSetup.entry_server()
+
+      # Link a couple viruses to `entry`
+      {v1, _} = DatabaseSetup.entry_virus(from_entry: entry)
+      {v2, _} = DatabaseSetup.entry_virus(from_entry: entry)
+
+      db_entry =
+        DatabaseInternal.fetch_server(
+          entry.entity_id, entry.network_id, entry.server_ip
+        )
+
+      # Returned the usual Database.Server entry
+      assert db_entry.entity_id == entry.entity_id
+      assert db_entry.server_id == entry.server_id
+
+      # With the linked viruses
+      assert Enum.sort(db_entry.viruses) == Enum.sort([v1, v2])
     end
 
     test "returns empty when input isn't found" do

--- a/test/entity/internal/database_test.exs
+++ b/test/entity/internal/database_test.exs
@@ -10,6 +10,7 @@ defmodule Helix.Entity.Internal.DatabaseTest do
   alias HELL.TestHelper.Random
   alias Helix.Test.Network.Helper, as: NetworkHelper
   alias Helix.Test.Server.Setup, as: ServerSetup
+  alias Helix.Test.Software.Helper, as: SoftwareHelper
   alias Helix.Test.Universe.Bank.Setup, as: BankSetup
   alias Helix.Test.Entity.Setup, as: EntitySetup
   alias Helix.Test.Entity.Database.Setup, as: DatabaseSetup
@@ -151,6 +152,22 @@ defmodule Helix.Entity.Internal.DatabaseTest do
       refute entry.last_login_date
       refute entry.known_balance
       refute entry.notes
+    end
+  end
+
+  describe "add_virus/3" do
+    test "given a valid input, entry is created" do
+      {entry_server, _} = DatabaseSetup.entry_server()
+      virus_id = SoftwareHelper.id()
+
+      assert {:ok, entry_virus} =
+        DatabaseInternal.add_virus(
+          entry_server.entity_id, entry_server.server_id, virus_id
+        )
+
+      assert entry_virus.entity_id == entry_server.entity_id
+      assert entry_virus.server_id == entry_server.server_id
+      assert entry_virus.file_id == virus_id
     end
   end
 

--- a/test/entity/model/database/bank_account_test.exs
+++ b/test/entity/model/database/bank_account_test.exs
@@ -1,30 +1,30 @@
-defmodule Helix.Entity.Model.DatabaseBankAccountTest do
+defmodule Helix.Entity.Model.Database.BankAccountTest do
 
   use Helix.Test.Case.Integration
 
   alias Ecto.Changeset
-  alias Helix.Entity.Model.DatabaseBankAccount
+  alias Helix.Entity.Model.Database
 
   alias Helix.Test.Entity.Database.Setup, as: DatabaseSetup
 
   describe "update_changeset/2" do
     test "password change" do
-      {entry, _} = DatabaseSetup.fake_entry_bank_account([real_entity: false])
+      {entry, _} = DatabaseSetup.fake_entry_bank_account(real_entity: false)
       password = "woooooow"
       params = %{password: password}
 
-      changeset = DatabaseBankAccount.update_changeset(entry, params)
+      changeset = Database.BankAccount.update_changeset(entry, params)
 
       assert changeset.valid?
       assert Changeset.get_change(changeset, :password) == password
     end
 
     test "token change" do
-      {entry, _} = DatabaseSetup.fake_entry_bank_account([real_entity: false])
+      {entry, _} = DatabaseSetup.fake_entry_bank_account(real_entity: false)
       token = Ecto.UUID.generate()
       params = %{token: token}
 
-      changeset = DatabaseBankAccount.update_changeset(entry, params)
+      changeset = Database.BankAccount.update_changeset(entry, params)
 
       assert changeset.valid?
       assert Changeset.get_change(changeset, :token) == token

--- a/test/features/virus/collect_test.exs
+++ b/test/features/virus/collect_test.exs
@@ -192,12 +192,13 @@ defmodule Helix.Test.Features.Virus.CollectTest do
         bank_acc.balance + expected_earnings1 + expected_earnings2
 
       # Both viruses had their `running_time` reset to 0
+      # (returning 1 is OK because slower systems (travis))
       new_virus1 = VirusQuery.fetch(file1.file_id)
-      assert new_virus1.running_time == 0
+      assert_in_delta new_virus1.running_time, 0, 1
       assert new_virus1.is_active?
 
       new_virus2 = VirusQuery.fetch(file2.file_id)
-      assert new_virus2.running_time == 0
+      assert_in_delta new_virus2.running_time, 0, 1
       assert new_virus2.is_active?
 
       # Processes no longer exist

--- a/test/software/event/handler/virus_test.exs
+++ b/test/software/event/handler/virus_test.exs
@@ -37,8 +37,9 @@ defmodule Helix.Software.Event.Handler.VirusTest do
       EventHelper.emit(event)
 
       # Virus running time has been updated
+      # (returning 1 is OK because slower systems (travis))
       virus = VirusQuery.fetch(file.file_id)
-      assert virus.running_time == 0
+      assert_in_delta virus.running_time, 0, 1
       assert virus.is_active?
     end
   end

--- a/test/software/websocket/requests/virus/collect_test.exs
+++ b/test/software/websocket/requests/virus/collect_test.exs
@@ -121,6 +121,9 @@ defmodule Helix.Software.Websocket.Requests.Virus.CollectTest do
           connect_opts: [entity_id: entity.entity_id]
         )
 
+      bounce = NetworkSetup.Bounce.bounce!(entity_id: entity.entity_id)
+      bank_account = BankSetup.account!(owner_id: entity.entity_id)
+
       {virus1, %{file: file1}} =
         SoftwareSetup.Virus.virus(
           entity_id: entity.entity_id,
@@ -134,9 +137,6 @@ defmodule Helix.Software.Websocket.Requests.Virus.CollectTest do
           is_active?: true,
           real_file?: true
         )
-
-      bounce = NetworkSetup.Bounce.bounce!(entity_id: entity.entity_id)
-      bank_account = BankSetup.account!(owner_id: entity.entity_id)
 
       params =
         %{

--- a/test/support/entity/database/setup.ex
+++ b/test/support/entity/database/setup.ex
@@ -2,8 +2,7 @@ defmodule Helix.Test.Entity.Database.Setup do
 
   alias Helix.Cache.Query.Cache, as: CacheQuery
   alias Helix.Server.Query.Server, as: ServerQuery
-  alias Helix.Entity.Model.DatabaseBankAccount
-  alias Helix.Entity.Model.DatabaseServer
+  alias Helix.Entity.Model.Database
   alias Helix.Entity.Model.Entity
   alias Helix.Entity.Repo, as: EntityRepo
 
@@ -49,7 +48,7 @@ defmodule Helix.Test.Entity.Database.Setup do
     password = Access.get(opts, :password, nil)
 
     entry =
-      %DatabaseServer{
+      %Database.Server{
         entity_id: entity.entity_id,
         network_id: nip.network_id,
         server_ip: nip.ip,
@@ -96,7 +95,7 @@ defmodule Helix.Test.Entity.Database.Setup do
     atm_ip = ServerQuery.get_ip(acc.atm_id, NetworkHelper.internet_id())
 
     entry =
-      %DatabaseBankAccount{
+      %Database.BankAccount{
         entity_id: entity_id,
         atm_id: acc.atm_id,
         account_number: acc.account_number,

--- a/test/support/server/helper.ex
+++ b/test/support/server/helper.ex
@@ -131,4 +131,10 @@ defmodule Helix.Test.Server.Helper do
   """
   def get_all,
     do: ServerRepo.all(from s in Server)
+
+  @doc """
+  Generates a random Server ID
+  """
+  def id,
+    do: Server.ID.generate()
 end

--- a/test/support/software/helper.ex
+++ b/test/support/software/helper.ex
@@ -101,6 +101,12 @@ defmodule Helix.Test.Software.Helper do
     do: Random.number(min: 10, max: 50)
 
   @doc """
+  Generates a `File.ID`
+  """
+  def id,
+    do: File.ID.generate()
+
+  @doc """
   FileModel performs some operation on the file path, like ensuring leading
   slashes and removing trailing slashes. We try to mock this internal formatting
   so our tests can verify the resulting path.

--- a/test/support/software/helper.ex
+++ b/test/support/software/helper.ex
@@ -76,6 +76,17 @@ defmodule Helix.Test.Software.Helper do
     end)
   end
 
+  @doc """
+  Returns the software extension
+  """
+  def get_extension(file = %File{}),
+    do: get_extension(file.software_type)
+  def get_extension(type) when is_atom(type) do
+    type
+    |> Software.Type.get()
+    |> Map.fetch!(:extension)
+  end
+
   defp generate_file_module(module, version) do
     data = File.Module.Data.new(%{name: module, version: version})
 


### PR DESCRIPTION
Now the virus information is returned on the DatabaseIndex, during the AccountBootstrap process. This should be enough for the Client to properly render virus information on the `HackedDatabase` and `VirusPanel` apps.

#### Incidental

- [x] Refactored `DatabaseServer` and `DatabaseBankAccount` to submodules (`Database.Server` and `Database.BankAccount`)
- [x] (Attempt to) Fix VirusCollect-related tests failing on slow systems (travis)

----

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/395)
<!-- Reviewable:end -->
