### PR TITLE
Add support for client-performed actions

### DIFF
--- a/lib/account/websocket/channel/account.ex
+++ b/lib/account/websocket/channel/account.ex
@@ -8,6 +8,7 @@ channel Helix.Account.Websocket.Channel.Account do
   alias Helix.Account.Websocket.Channel.Account.Join, as: AccountJoin
   alias Helix.Account.Websocket.Requests.Bootstrap, as: BootstrapRequest
   alias Helix.Account.Websocket.Requests.Logout, as: LogoutRequest
+  alias Helix.Client.Websocket.Requests.Action, as: ClientActionRequest
   alias Helix.Client.Websocket.Requests.Setup, as: ClientSetupProxyRequest
   alias Helix.Network.Websocket.Requests.Bounce.Create, as: BounceCreateRequest
   alias Helix.Network.Websocket.Requests.Bounce.Update, as: BounceUpdateRequest
@@ -56,6 +57,23 @@ channel Helix.Account.Websocket.Channel.Account do
   + base errors
   """
   topic "client.setup", ClientSetupProxyRequest
+
+  @doc """
+  Notifies the backend that `action` has been performed by the player.
+
+  Params:
+    *action: Action performed by the player. [0]
+
+  Returns: :ok
+
+  Errors:
+  - "bad_action": The given `action` is not valid. See [0].
+  + base errors
+
+  Notes:
+    [0] - List of all possible actions can be found at `ClientModel`.
+  """
+  topic "client.action", ClientActionRequest
 
   @doc """
   Replies to a Storyline email.

--- a/lib/client/model/client.ex
+++ b/lib/client/model/client.ex
@@ -1,5 +1,7 @@
 defmodule Helix.Client.Model.Client do
 
+  alias Helix.Client.Web1.Model.Web1
+
   @type t :: client
   @type client ::
     :web1
@@ -8,12 +10,18 @@ defmodule Helix.Client.Model.Client do
     | :mobile2
     | :unknown
 
+  @type action :: Web1.action
+
   @clients [:web1, :web2, :mobile1, :mobile2, :unknown]
   @clients_str Enum.map(@clients, &to_string/1)
 
+  @spec valid_clients() ::
+    [client]
   def valid_clients,
     do: @clients
 
+  @spec valid_client?(binary | atom) ::
+    boolean
   def valid_client?(client) when is_binary(client),
     do: client in @clients_str
   def valid_client?(client) when is_atom(client),

--- a/lib/client/web1/event/action.ex
+++ b/lib/client/web1/event/action.ex
@@ -1,0 +1,41 @@
+import Helix.Event
+
+# Note to self: When implementing `web2`, use a macro that generates the
+# skeleton of this event and each client then specializes it.
+defmodule Helix.Client.Web1.Event.Action do
+
+  event Performed do
+    @moduledoc """
+    `Web1ActionPerformedEvent` is emitted when the client performed a custom
+    action that should be tracked by the backend for a specific behaviour.
+    Examples include the tutorial quest, which awaits for the player to open
+    apps in order to proceed with the storyline.
+    """
+
+    alias Helix.Entity.Model.Entity
+    alias Helix.Client.Web1.Model.Web1
+
+    event_struct [:entity_id, :action]
+
+    @type t ::
+      %__MODULE__{
+        entity_id: Entity.id,
+        action: Web1.action
+      }
+
+    @spec new(Entity.id, Web1.action) ::
+      t
+    def new(entity_id, action) do
+      %__MODULE__{
+        entity_id: entity_id,
+        action: action
+      }
+    end
+
+    listenable do
+      listen(event) do
+        [event.entity_id]
+      end
+    end
+  end
+end

--- a/lib/client/web1/model/web1.ex
+++ b/lib/client/web1/model/web1.ex
@@ -1,0 +1,12 @@
+defmodule Helix.Client.Web1.Model.Web1 do
+
+  @type action :: :tutorial_accessed_task_manager
+
+  @actions [:tutorial_accessed_task_manager]
+  @actions_str Enum.map(@actions, &to_string/1)
+
+  def valid_actions,
+    do: @actions
+  def valid_actions_str,
+    do: @actions_str
+end

--- a/lib/client/websocket/requests/action.ex
+++ b/lib/client/websocket/requests/action.ex
@@ -1,0 +1,56 @@
+import Helix.Websocket.Request
+
+request Helix.Client.Websocket.Requests.Action do
+
+  import HELL.Macros
+
+  alias Helix.Client.Public.Client, as: ClientPublic
+  alias Helix.Client.Web1.Model.Web1
+
+  def check_params(request, socket) do
+    with \
+      true <-
+        valid_action?(socket.assigns.client, request.unsafe["action"])
+        || :bad_action,
+      action = String.to_existing_atom(request.unsafe["action"])
+    do
+      update_params(request, %{action: action}, reply: true)
+    else
+      :bad_action ->
+        reply_error(request, "bad_action")
+
+      _ ->
+        bad_request(request)
+    end
+  end
+
+  defp valid_action?(client, action) do
+    valid_actions_str =
+      case client do
+        :web1 ->
+          Web1.valid_actions_str()
+
+        _ ->
+          []
+      end
+
+    Enum.member?(valid_actions_str, action)
+  end
+
+  def check_permissions(request, _socket),
+    do: {:ok, request}
+
+  def handle_request(request, socket) do
+    entity_id = socket.assigns.entity_id
+    client = socket.assigns.client
+    action = request.params.action
+
+    hespawn fn ->
+      ClientPublic.broadcast_action(client, entity_id, action)
+    end
+
+    reply_ok(request)
+  end
+
+  render_empty()
+end

--- a/lib/core/listener/listener.ex
+++ b/lib/core/listener/listener.ex
@@ -1,7 +1,7 @@
 defmodule Helix.Core.Listener do
   @moduledoc """
   Main interface to be used by any service that would like to listen/unlisten to
-  events happening a specific `object_id`.
+  events happening to a specific `object_id`.
 
   I'm a Listener
 

--- a/lib/event/dispatcher.ex
+++ b/lib/event/dispatcher.ex
@@ -40,6 +40,7 @@ defmodule Helix.Event.Dispatcher do
   alias Helix.Core.Listener.Event.Handler.Listener, as: ListenerHandler
   alias Helix.Account.Event, as: AccountEvent
   alias Helix.Account.Event.Handler, as: AccountHandler
+  alias Helix.Client.Web1.Event, as: Web1Event
   alias Helix.Entity.Event, as: EntityEvent
   alias Helix.Entity.Event.Handler, as: EntityHandler
   alias Helix.Log.Event, as: LogEvent
@@ -79,6 +80,13 @@ defmodule Helix.Event.Dispatcher do
   event AccountEvent.Account.Verified,
     AccountHandler.Account,
     :account_created
+
+  ##############################################################################
+  # Client events
+  ##############################################################################
+
+  # All
+  event Web1Event.Action.Performed
 
   ##############################################################################
   # Entity events

--- a/lib/story/model/step/macros.ex
+++ b/lib/story/model/step/macros.ex
@@ -16,6 +16,7 @@ defmodule Helix.Story.Model.Step.Macros do
   alias Helix.Story.Action.Story, as: StoryAction
   alias Helix.Story.Query.Story, as: StoryQuery
 
+  alias Helix.Client.Web1.Event.Action.Performed, as: Web1ActionPerformedEvent
   alias Helix.Process.Event.Process.Created, as: ProcessCreatedEvent
   alias Helix.Story.Event.Email.Sent, as: StoryEmailSentEvent
   alias Helix.Story.Event.Reply.Sent, as: StoryReplySentEvent
@@ -153,6 +154,18 @@ defmodule Helix.Story.Model.Step.Macros do
               {:noop, []}
             end
           end
+
+          @doc """
+          Callback used to filter the client action, making sure the action
+          broadcasted is the desired one. If so, relays to the proper callback.
+          """
+          callback :cb_client_action, event, meta do
+            if to_string(event.action) == meta.action do
+              relay_callback meta.relay_cb, event, meta
+            else
+              {:noop, []}
+            end
+          end
         end
       end
     end
@@ -247,6 +260,29 @@ defmodule Helix.Story.Model.Step.Macros do
 
       story_listen unquote(element_id), ProcessCreatedEvent,
         meta, :cb_process_started
+    end
+  end
+
+  @doc """
+  Listeners that triggers once the player has performed `action` on the client.
+  """
+  defmacro on_client_action(_client, action, entity_id, callback) do
+    quote do
+
+      # TODO: Proper handler for multiple clients based on the `client` var
+      event = Web1ActionPerformedEvent
+
+      {callback_name, extra_meta} = get_callback_data(unquote(callback))
+
+      meta =
+        %{
+          action: unquote(action),
+          relay_cb: callback_name
+        }
+        |> Map.merge(extra_meta)
+
+      story_listen unquote(entity_id), event, meta, :cb_client_action
+
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
+%{
+  "bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "bcrypt_elixir": {:hex, :bcrypt_elixir, "1.0.5", "cca70b5c8d9a98a0151c2d2796c728719c9c4b3f8bd2de015758ef577ee5141e", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, optional: false]}]},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "burette": {:git, "https://github.com/HackerExperience/burette", "f44c71c5fcca23a3086b68efc32c7c6196ad1bf5", []},
@@ -36,10 +37,11 @@
   "plug": {:hex, :plug, "1.4.5", "7b13869283fff6b8b21b84b8735326cc012c5eef8607095dc6ee24bd0a273d8e", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "postgrex": {:hex, :postgrex, "0.13.4", "f58e319c5451bfda86ba6a45ce6dca311193d0a9861323d0d16e8d02e25adc41", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "postgrex": {:hex, :postgrex, "0.13.4", "f58e319c5451bfda86ba6a45ce6dca311193d0a9861323d0d16e8d02e25adc41", [:mix], [{:connection, "~> 1.0", [repo: "hexpm", hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [repo: "hexpm", hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [repo: "hexpm", hex: :decimal, optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "timber": {:hex, :timber, "2.6.1", "946dee43730b30748c7a3ed0085abe8690dcbaf4cd96031caba676b938dd40a6", [:mix], [{:ecto, ">= 2.0.0 and < 2.3.0", [hex: :ecto, optional: true]}, {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9", [hex: :hackney, optional: false]}, {:msgpax, "~> 1.0", [hex: :msgpax, optional: false]}, {:phoenix, ">= 1.2.0 and < 1.4.0", [hex: :phoenix, optional: true]}, {:plug, ">= 1.2.0 and < 1.5.0", [hex: :plug, optional: true]}, {:poison, "~> 1.0 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "timex": {:hex, :timex, "3.1.24", "d198ae9783ac807721cca0c5535384ebdf99da4976be8cefb9665a9262a1e9e3", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []},
+}

--- a/test/account/websocket/channel/account/topics/client_test.exs
+++ b/test/account/websocket/channel/account/topics/client_test.exs
@@ -1,0 +1,38 @@
+defmodule Helix.Account.Websocket.Channel.Account.Topics.ClientTest do
+
+  use Helix.Test.Case.Integration
+
+  import Phoenix.ChannelTest
+
+  alias Helix.Test.Channel.Setup, as: ChannelSetup
+
+  describe "client.action" do
+    test "broadcasts that `action` has been performed" do
+      {socket, _} = ChannelSetup.join_account(socket_opts: [client: :web1])
+
+      params =
+        %{
+          "action" => "tutorial_accessed_task_manager"
+        }
+
+      ref = push socket, "client.action", params
+      assert_reply ref, :ok, response
+
+      assert Enum.empty?(response.data)
+    end
+
+    test "returns error when `action` does not exist" do
+      {socket, _} = ChannelSetup.join_account(socket_opts: [client: :web1])
+
+      params =
+        %{
+          "action" => "invalid_client_action"
+        }
+
+      ref = push socket, "client.action", params
+      assert_reply ref, :error, response
+
+      assert response.data.message == "bad_action"
+    end
+  end
+end


### PR DESCRIPTION
Sometimes the backend may need to know that the player has performed some action on the client. This is mostly useful for storyline quests, as some steps may only proceed after the player performs an action like opening an app or clicking somewhere.

Obviously without an input from the frontend, it's impossible for Helix to know when this happened. That's what this PR solves: it adds a `client.action` endpoint on the AccountChannel, which may be used by HEBorn to notify Helix that the user performed some action.

Naturally this sort of input isn't 100% reliable, since it originated on the client-side. If required, the backend may keep track of how many times the given action was performed, to make sure it only happens once (but that's only if it makes sense for that specific action). Since most client actions are related to the storyline (and do not offer a reward or something like that), it's OK to simply ignore repeated messages, but beware.

Other than that, if a more strict validation is required, the backend should check for the player context. Suppose action `A` can only be performed while player is going through step `S`. This can be verified on the backend. Other than that, little can be done to further verify the context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/398)
<!-- Reviewable:end -->
