### PR TITLE
Include CID information on ServerNotifications

### DIFF
--- a/lib/notification/event/notification.ex
+++ b/lib/notification/event/notification.ex
@@ -81,7 +81,7 @@ defmodule Helix.Notification.Event.Notification do
           %{server_id: notification.server_id |> to_string()}
         else
           notification.server_id
-          |> CacheQuery.from_server_get_nips()
+          |> CacheQuery.from_server_get_nips!()
           |> List.first()
           |> Utils.stringify_map()
         end

--- a/lib/notification/event/notification.ex
+++ b/lib/notification/event/notification.ex
@@ -28,6 +28,11 @@ defmodule Helix.Notification.Event.Notification do
 
     publish do
 
+      alias HELL.Utils
+      alias Helix.Account.Model.Account
+      alias Helix.Cache.Query.Cache, as: CacheQuery
+      alias Helix.Entity.Query.Entity, as: EntityQuery
+
       @event :notification_added
 
       def generate_payload(event, _socket) do
@@ -64,8 +69,23 @@ defmodule Helix.Notification.Event.Notification do
 
       defp get_extra_data(%Notification.Account{}),
         do: %{}
-      defp get_extra_data(%Notification.Server{}),
-        do: %{}
+      defp get_extra_data(notification = %Notification.Server{}) do
+        # We have to publish the server information to the Client, so it knows
+        # where to display the notification.
+        # If the server belongs to the given account, we publish the raw
+        # `server_id`. Otherwise, we publish the server's `network_id` and `ip`.
+        entity = EntityQuery.fetch_by_server(notification.server_id)
+        account_id = Account.cast_from_entity(entity.entity_id)
+
+        if account_id == notification.account_id do
+          %{server_id: notification.server_id |> to_string()}
+        else
+          notification.server_id
+          |> CacheQuery.from_server_get_nips()
+          |> List.first()
+          |> Utils.stringify_map()
+        end
+      end
     end
   end
 

--- a/test/features/file/transfer_test.exs
+++ b/test/features/file/transfer_test.exs
@@ -104,6 +104,10 @@ defmodule Helix.Test.Features.File.TransferTest do
       assert notification_added_event.data.class == :server
       assert notification_added_event.data.code == :file_downloaded
 
+      # Notification contains information about which server it took place
+      assert notification_added_event.data.server_id ==
+        to_string(gateway.server_id)
+
       # Notification contains required data
       notification_data = notification_added_event.data.data
       assert notification_data.id == to_string(new_file.file_id)

--- a/test/id/id_test.exs
+++ b/test/id/id_test.exs
@@ -153,6 +153,7 @@ defmodule Helix.IDTest do
       refute slice(proc3_s1_id_bin, 24..53) == slice(proc3_s2_id_bin, 24..53)
     end
 
+    skip_on_travis_slowpoke()
     test "benchmark" do
       # Generate 1000 IDs without parent and gp
       time_start = DateTime.utc_now() |> DateTime.to_unix(:millisecond)


### PR DESCRIPTION
This is required so the Client can know which server to assign the notification to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/helix/409)
<!-- Reviewable:end -->
